### PR TITLE
In numeric mode - treats digit '0' and decimal point '.' as numeric

### DIFF
--- a/src/cmds_normal.c
+++ b/src/cmds_normal.c
@@ -66,6 +66,7 @@ void do_normalmode(struct block * buf) {
             break;
 
         case '0':
+            if (atoi(get_conf_value("numeric_zero")) == 1) goto numeric;
         case OKEY_HOME:
             lastrow = currow;
             lastcol = curcol;
@@ -337,6 +338,7 @@ void do_normalmode(struct block * buf) {
 
         // repeat last command
         case '.':
+            if (atoi(get_conf_value("numeric_decimal")) == 1) goto numeric;
             copybuffer(lastcmd_buffer, buf); // nose graba en lastcmd_buffer!!
             cmd_multiplier = 1;
             exec_mult(buf, COMPLETECMDTIMEOUT);
@@ -1006,7 +1008,8 @@ void do_normalmode(struct block * buf) {
         // input of numbers
         default:
         numeric:
-            if ( (isdigit(buf->value) || buf->value == '-' || buf->value == '+') &&
+            if ( (isdigit(buf->value) || buf->value == '-' || buf->value == '+' || 
+                  ( buf->value == '.' &&  atoi(get_conf_value("numeric_decimal")) )) &&
                 atoi(get_conf_value("numeric")) ) {
                 insert_edit_submode='=';
                 chg_mode(insert_edit_submode);

--- a/src/conf.c
+++ b/src/conf.c
@@ -14,6 +14,8 @@ void store_default_config_values() {
     put(user_conf_d, "external_functions", "0");
     put(user_conf_d, "xlsx_readformulas", "0");
     put(user_conf_d, "quit_afterload", "0");
+    put(user_conf_d, "numeric_zero", "0");
+    put(user_conf_d, "numeric_decimal", "0");
 
     // we calc get gmtoffset
     #ifdef USELOCALE


### PR DESCRIPTION
I have been using sc-im for a while now with no issues.  A couple of days ago I was typing up a column of numbers in numeric mode that I needed summed and noticed that things weren't quite what I expected.

The data was
.5
10
10
.5
.5
.5
.5

Which should be 22.5
But my totals in sc-im showed 45.

I realized I had assumed that decimal points would be treated as such in numeric mode.

So then I thought I'd enter every decimal with a leading 0

That also didnt work - as everytime I hit the '0' it would move the cursor to the leftmost column.

So I created two options --> numeric_zero and numeric_decimal.  When these are each set, the corresponding zero and decimal will initiate numeric entry, but only when numeric mode is also set.

 