### PR TITLE
Fix realpath() issue

### DIFF
--- a/src/help.c
+++ b/src/help.c
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <fcntl.h>
+#include <limits.h>
 #include "sc.h"
 #include "macros.h"
 #include "screen.h"
@@ -35,7 +36,7 @@ int load_help () {
 
     // last change to read the help file !
     if (! f ) {
-        char cwd[1024];
+        char cwd[PATH_MAX];
         extern char exepath[];
         if (realpath(exepath, cwd) == NULL) return -1;
         char * str_pos = strrchr(cwd, '/');


### PR DESCRIPTION
`realpath()` can write up to `PATH_MAX` bytes into the provided buffer. From the manpage:
```
The resulting pathname is stored as a null-terminated string, up to a maximum of PATH_MAX bytes, in the buffer pointed to by resolved_path. 
```

Make sure that there is enough space.

Fixes #63.