### PR TITLE
Fix `exename` buffer overflow

### DIFF
--- a/src/help.c
+++ b/src/help.c
@@ -37,7 +37,7 @@ int load_help () {
     // last change to read the help file !
     if (! f ) {
         char cwd[PATH_MAX];
-        extern char exepath[];
+        extern char *exepath;
         if (realpath(exepath, cwd) == NULL) return -1;
         char * str_pos = strrchr(cwd, '/');
         if (str_pos == NULL) return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -45,7 +45,7 @@ int shall_quit = 0;
 unsigned int curmode = NORMAL_MODE;
 int maxrow, maxcol;
 char curfile[PATHLEN];
-char exepath[PATHLEN];
+char *exepath;
 
 int changed;
 int cellassign;
@@ -344,7 +344,7 @@ void read_argv(int argc, char ** argv) {
             strcpy(curfile, argv[i]);
         }
     }
-    strcpy(exepath, argv[0]);
+    exepath = argv[0];
 }
 
 


### PR DESCRIPTION
Avoid a possible buffer overflow by storing the pointer (which is guaranteed to be in memory for the run of the application) instead of copying the value. This also saves a bit of memory.