### PR TITLE
Fix uppercase function

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -291,14 +291,14 @@ void write_fd(register FILE *f, int r0, int c0, int rn, int cn) {
                     struct enode * e = new((*pp)->ucolor->fg, (struct enode *)0, (struct enode *)0);
                     decompile(e, 0);
                     uppercase(line);
-                    if (line[0] == '@') del_char(line, 0); // FIXME THIS !!! SEE ISSUE #42 in github
+                    del_char(line, 0);
                     sprintf(strcolor, "fg=%s", &line[0]);
                     free(e);
                     linelim=0;
                     e = new((*pp)->ucolor->bg, (struct enode *)0, (struct enode *)0);
                     decompile(e, 0);
                     uppercase(line);
-                    if (line[0] == '@') del_char(line, 0); // FIXME THIS !!! SEE ISSUE #42 in github
+                    del_char(line, 0);
                     sprintf(strcolor + strlen(strcolor), " bg=%s", &line[0]);
                     free(e);
 

--- a/src/utils/string.c
+++ b/src/utils/string.c
@@ -252,9 +252,8 @@ char * str_replace ( const char * string, const char * substr, const char * repl
 }
 
 void uppercase(char * sPtr) {
-    while(*sPtr != '\0') {
-         *sPtr++ = toupper(*sPtr);
-    }
+    for(; *sPtr != '\0'; ++sPtr)
+         *sPtr = toupper(*sPtr);
 }
 
 int sc_isprint(int d) {


### PR DESCRIPTION
Fix the `uppercase` function to not depend on undefined behavior.

`sPtr` was used twice in a statement, of which once in a in-place increment - in that case the sequence depends on C compiler, and for many compilers this resulted in removing the first character.

Explicitly delete the first character of the result in `write_fd`, the only callsite.