### PR TITLE
Fixed typo

### DIFF
--- a/src/xls.c
+++ b/src/xls.c
@@ -59,7 +59,8 @@ int open_xls(char * fname, char * encoding) {
     for (r = 0; r <= pWS->rows.lastrow; r++) { // rows
         for (c = 0; c <= pWS->rows.lastcol; c++) { // cols
             xlsCell * cell = xls_cell(pWS, r, c);
-            if ((! cell) || (cell->isHidden)) continue;
+            //if ((! cell) || (cell->isHidden)) continue;
+            if ((! cell) || (cell->ishiden)) continue; // Unfortunately libxls spells this "ishiden"
 
             // TODO enable rowspan ?
             //if (cell->rowspan > 1) continue;


### PR DESCRIPTION
Unfortunately libxls spells the boolean flag designating whether the cell is
hidden "ishiden" (rather than "isHidden", which would be much better).