### PR TITLE
Allow both backspace codes in any build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -49,15 +49,6 @@ NETBSD :=
 #MACOSX := -DMACOSX
 MACOSX :=
 
-# If you have a problem with your BACKSPACE key in LINUX
-# please set this flag. The problem is that different LINUX
-# distros report different keycodes for the BACKSPACE key.
-# Arch GNU / Linux would probably should set this.
-# Debian GNU / Linux probably should not.
-#BSKEY_HACK := -DBSKEY_HACK
-BSKEY_HACK :=
-
-
 # Set SIMPLE for lex.c if you don't want arrow keys or lex.c blows up
 #SIMPLE := -DSIMPLE
 
@@ -143,7 +134,7 @@ UNDO := -DUNDO
 MAXROWS := 65536
 
 #CFLAGS := -O2 -Wall -pipe -g
-CFLAGS := $(LINUX) $(FREEBSD) $(NETBSD) $(MACOSX) $(BSKEY_HACK) -O2 -Wall -pipe -g -I/usr/include/libxml2 $(shell pkg-config --cflags ncursesw)
+CFLAGS := $(LINUX) $(FREEBSD) $(NETBSD) $(MACOSX) -O2 -Wall -pipe -g -I/usr/include/libxml2 $(shell pkg-config --cflags ncursesw)
 CFLAGS := $(CFLAGS) $(USECOLORS) $(USELOCALE) $(UNDO) $(SIGVOID) $(DFLT_PAGER)
 CFLAGS := $(CFLAGS) $(IEEE_MATH) $(RINT) $(REGEX) $(LIBRARY) -DMAXROWS=$(MAXROWS)
 CFLAGS := $(CFLAGS) $(HELP_PATH) $(SNAME) $(NO_NOTIMEOUT) $(SIMPLE) $(XLS) $(XLSX) $(HISTORY_FILE)

--- a/src/cmds_command.c
+++ b/src/cmds_command.c
@@ -116,7 +116,7 @@ void do_commandmode(struct block * sb) {
     //-------------------------------------
     // Normal KEY handlers for this MODE
     //-------------------------------------
-    if (sb->value == OKEY_BS) {            // BS
+    if (sb->value == OKEY_BS || sb->value == OKEY_BS2) {  // BS
         if ( ! wcslen(inputline) || ! real_inputline_pos ) return;
         int l = wcwidth(inputline[real_inputline_pos - 1]);
         real_inputline_pos--;

--- a/src/cmds_insert.c
+++ b/src/cmds_insert.c
@@ -34,7 +34,7 @@ void do_insertmode(struct block * sb) {
             show_header(input_win);
         }
 
-    } else if (sb->value == OKEY_BS) {     // BS
+    } else if (sb->value == OKEY_BS || sb->value == OKEY_BS2) {  // BS
         if ( ! wcslen(inputline) || ! real_inputline_pos ) return;
 
         int l = wcwidth(inputline[real_inputline_pos - 1]);

--- a/src/help.c
+++ b/src/help.c
@@ -165,7 +165,7 @@ void help() {
 
             int d = wgetch(input_win);
             while (d != OKEY_ENTER && d != OKEY_ESC) {
-                if (d == OKEY_BS) {
+                if (d == OKEY_BS || d == OKEY_BS2) {
                     del_char(hline, strlen(hline) - 1);
                 } else {
                     sprintf(hline + strlen(hline), "%c", d);
@@ -193,7 +193,7 @@ void help() {
             wrefresh(input_win);
             d = wgetch(input_win);
             while (d != OKEY_ENTER && d != OKEY_ESC) {
-                if (d == OKEY_BS) {
+                if (d == OKEY_BS || d == OKEY_BS2) {
                     del_char(word_looked, strlen(word_looked) - 1);
                 } else {
                     //sprintf(word_looked, "%s%c", word_looked, d);

--- a/src/macros.h
+++ b/src/macros.h
@@ -23,13 +23,8 @@
 #define OKEY_DOWN        0x102
 #define OKEY_UP          0x103
 #define OKEY_DEL         0x14a
-
-#if ( defined(NETBSD) || defined(MACOSX) || defined(BSKEY_HACK) )
-#define OKEY_BS          0x7f
-#else
 #define OKEY_BS          0x107
-#endif
-
+#define OKEY_BS2         0x7f   // some BSDs, Linux distros, SSH/tmux configs
 #define OKEY_HOME        0x106
 #define OKEY_END         0x168
 #define OKEY_PGUP        0x153

--- a/src/maps.c
+++ b/src/maps.c
@@ -260,7 +260,7 @@ void get_mapstr_buf (struct block * b, char * str) {
             strcat(str, "<UP>");                                 // UP
         } else if (a->value == OKEY_DEL) {
             strcat(str, "<DEL>");                                // DEL
-        } else if (a->value == OKEY_BS) {
+        } else if (a->value == OKEY_BS || a->value == OKEY_BS2) {
             strcat(str, "<BS>");                                 // BS
         } else if (a->value == OKEY_HOME) {
             strcat(str, "<HOME>");                               // HOME


### PR DESCRIPTION
Backspace is represented differently on different operating systems. This
was previously addressed with OS flags but even between Linux
distributions and SSH clients the representation can differ.

This commit allows both representations in any build, removing the hack
flag.