### PR TITLE
Remove problematic split() function

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -42,18 +42,16 @@ int exec_cmd (char * line) {
         close(my_pipe[0]);   // child doesn't read
         dup2(my_pipe[1], 1); // redirect stdout
 
-        char * l = line;
-        int j;
-        l = rtrim(ltrim(line, ' '), ' ');
-        char ** param = split(l, ' ', 1);
-        execvp(param[0], param);
+        int argc = 1;
+        for (char *p = line; *p; p++)
+            argc += (*p == ' ');
+        char **argv = calloc(argc+1, sizeof(char*));
+        for (int i = 0; i < argc; i++)
+            argv[i] = strsep(&line, " ");
 
-        for (j=0; param[j]; j++) {
-            free(param[j]);
-        }
-        free(param);
-        param = NULL;
+        execvp(argv[0], argv);
 
+        free(argv);
         printf("Error executing command. ");
         exit(-1);
 

--- a/src/main.c
+++ b/src/main.c
@@ -328,20 +328,17 @@ int exit_app(int status) {
 // we read parameters passed to SC-IM executable
 // and store them in user_conf dictionary
 void read_argv(int argc, char ** argv) {
-    int i, j;
-    for (i = 1; i < argc; i++) {
+    for (int i = 1; i < argc; i++) {
         if ( ! strncmp(argv[i], "--", 2) ) {       // it was passed a parameter
-            char ** s = split(argv[i], '=', 0);
-            if (s[1] != NULL)
-                put(user_conf_d, &s[0][2], s[1]);  // --parameter=value
-            else
-                put(user_conf_d, &s[0][2], "1");   // --parameter
-
-            for (j=0; s[j]; j++) {
-                free(s[j]);
+            char *dup = strdup(argv[i]);
+            char *rest = dup;
+            char *name = strsep(&rest, "=");
+            if (rest) {
+                put(user_conf_d, &name[2], rest);  // --parameter=value
+            } else {
+                put(user_conf_d, &name[2], "1");   // --parameter
             }
-            free(s);
-            s = NULL;
+            free(dup);
         } else {                                   // it was passed a file
             strncpy(curfile, argv[i], PATHLEN-1);
         }

--- a/src/utils/string.c
+++ b/src/utils/string.c
@@ -175,33 +175,6 @@ int is_idchar (int d) {
     return 0;
 }
 
-char ** split(char *string, const char delimiter, int lastnull) {
-    int length = 0, count = 0, i = 0, j = 0;
-    while(*(string++)) {
-        if (*string == delimiter) count++;
-        length++;
-    }
-    string -= (length + 1); // string was incremented one more than length
-    char **array = (char **)malloc(sizeof(char *) * (length + 1 + lastnull));
-    char ** base = array;
-    for(i = 0; i < (count + 1); i++) {
-        j = 0;
-        while(string[j] != delimiter) j++;
-        j++;
-        * array = (char *) malloc(sizeof(char) * j);
-        memcpy(*array, string, (j-1));
-        (*array)[j-1] = '\0';
-        string += j;
-        array++;
-    }
-    if (lastnull) {
-        *array = NULL;
-        array++;
-    }
-    *array = '\0';
-    return base;  
-}
-
 char * rtrim(char * string, char junk) {
     char * original = string + strlen(string);
     while(*--original == junk);

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -16,7 +16,6 @@ void subst(char * s, char from, char to);
 int is_idchar (int d);
 int str_in_str(char * s, char * b);
 int wstr_in_wstr(wchar_t * s, wchar_t * b);
-char ** split(char *string, const char delimiter, int lastnull);
 char * ltrim(char *string, char junk);
 char * rtrim(char * string, char junk);
 int isnumeric(char * string);


### PR DESCRIPTION
Major issues with split():
 1. It allocates too many array entries
 2. It will seek into out of bounds memory
 3. It seeds to many nulls

See https://github.com/andmarti1424/sc-im/issues/116 for details.

This commit removes split() and replaces its use with some stdlib
functions.

Tests performed:

 - ./scim --half_page_scroll   (verify using :set)
 - ./scim --half_page_scroll=2 (verify using :set)
 - !ls -l