### PR TITLE
Set _GNU_SOURCE (removing wcwidth/wcswidth declarations)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -138,6 +138,7 @@ CFLAGS := $(LINUX) $(FREEBSD) $(NETBSD) $(MACOSX) -O2 -Wall -pipe -g -I/usr/incl
 CFLAGS := $(CFLAGS) $(USECOLORS) $(USELOCALE) $(UNDO) $(SIGVOID) $(DFLT_PAGER)
 CFLAGS := $(CFLAGS) $(IEEE_MATH) $(RINT) $(REGEX) $(LIBRARY) -DMAXROWS=$(MAXROWS)
 CFLAGS := $(CFLAGS) $(HELP_PATH) $(SNAME) $(NO_NOTIMEOUT) $(SIMPLE) $(XLS) $(XLSX) $(HISTORY_FILE)
+CFLAGS := $(CFLAGS) -D_GNU_SOURCE  # for wcwidth, wcswidth, tm_gmtoff
 
 LDLIBS := -lm $(shell pkg-config --libs ncursesw)
 #LDLIBS := -lm -lncurses -lxlsreader

--- a/src/interp.c
+++ b/src/interp.c
@@ -19,10 +19,6 @@
 #include <ctype.h>
 #include <errno.h>
 
-#ifndef __USE_XOPEN
-#define __USE_XOPEN
-#endif
-//#define _GNU_SOURCE 1
 #include <time.h>
 #include <string.h>
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -3,9 +3,6 @@ main_win: window that loads the spreadsheetssword:
 
     input_win: stdin and state bar window
 */
-#define _XOPEN_SOURCE_EXTENDED = 1
-
-
 #include <string.h>
 #include <ncurses.h>
 #include <stdio.h>

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -1,7 +1,5 @@
 #include <wchar.h>
 
-int wcswidth(const wchar_t * s, size_t n);
-int wcwidth(const wchar_t wc);
 int del_char(char * str, int posicion);
 int del_wchar(wchar_t * str, int posicion);
 


### PR DESCRIPTION
This re-applies the `wcwidth()` and `wcheight()` declaration removal, setting `_GNU_SOURCE` in `CFLAGS`.

`_GNU_SOURCE` is required for:
 - `wcwidth()` and `wcswidth()` through `_XOPEN_SOURCE`
 - `tm_gmtoff` which is not covered by `_XOPEN_SOURCE`