### PR TITLE
Address compiler warnings

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -61,12 +61,20 @@ int exec_cmd (char * line) {
         close(my_pipe[1]);   // parent doesn't write
         char reading_buf[2];
 
-        while (read(my_pipe[0], reading_buf, 1) > 0)
-            write(1, reading_buf, 1);
+        while (read(my_pipe[0], reading_buf, 1) > 0) {
+            if (!write(1, reading_buf, 1)) {
+                perror(NULL);
+                exit(-1);
+            }
+        }
 
         close(my_pipe[0]);
         wait(&waitres);
-        system("echo -n 'Press ENTER to return.'");
+        if (system("echo -n 'Press ENTER to return.'") == -1) {
+            /* system() call itself failed */
+            perror(NULL);
+            exit(-1);
+        }
 
         getchar();
         reset_prog_mode();

--- a/src/file.c
+++ b/src/file.c
@@ -540,7 +540,10 @@ int backup_file(char *path) {
         umask(oldumask);
         if (outfd < 0)
             return (0);
-        (void) chown(tpath, statbuf.st_uid, statbuf.st_gid);
+
+        if (!chown(tpath, statbuf.st_uid, statbuf.st_gid)) {
+            /* not fatal */
+        }
 
         while ((count = read(infd, buf, sizeof(buf))) > 0) {
             if (write(outfd, buf, count) != count) {

--- a/src/history.c
+++ b/src/history.c
@@ -74,8 +74,7 @@ void load_history(struct history * h) {
             f = fopen(infofile, "r");
             if (f == NULL) return;
             while ( feof(f) == 0 ) {
-
-                fgetws(linea, sizeof(linea), f);
+                if (!fgetws(linea, sizeof(linea) / sizeof(*linea), f)) break;
                 int s = wcslen(linea)-1;
                 del_range_wchars(linea, s, s);
 

--- a/src/main.c
+++ b/src/main.c
@@ -166,7 +166,10 @@ int main (int argc, char ** argv) {
     while (f != NULL && fgetws(stdin_buffer, BUFFERSIZE, f) != NULL) {
         send_to_interp(stdin_buffer);
     }
-    freopen("/dev/tty", "rw", stdin);
+    if (!freopen("/dev/tty", "rw", stdin)) {
+        perror(NULL);
+        exit(-1);
+    }
     flags = fcntl(fd, F_GETFL, 0);
     flags &= ~O_NONBLOCK;
     fcntl(fd, F_SETFL, flags);


### PR DESCRIPTION
(Compiling with GCC 4.8.4 on LXSS/Ubuntu)

 - unused results
 - incorrect size argument in fgetws

One unused result warning, for dup(), has not been addressed I'm not familiar with its use.