### PR TITLE
Replace obsolete finite() calls with isfinite()

### DIFF
--- a/src/dep_graph.c
+++ b/src/dep_graph.c
@@ -392,7 +392,7 @@ void EvalJustOneVertex(register struct ent * p, int i, int j, int rebuild_graph)
             cellerror = CELLOK;
             v = rebuild_graph ? eval(p, p->expr) : eval(NULL, p->expr);
 
-            if (cellerror == CELLOK && ! finite(v))
+            if (cellerror == CELLOK && ! isfinite(v))
                 cellerror = CELLERROR;
         }
         if ((cellerror != p->cellerror) || (v != p->v)) {

--- a/src/interp.c
+++ b/src/interp.c
@@ -759,7 +759,7 @@ double eval(register struct ent * ent, register struct enode * e) {
     case ';':    return (((int) eval(ent, e->e.o.left) & 7) +
                 (((int) eval(ent, e->e.o.right) & 7) << 3));
     case O_CONST:
-            if (! finite(e->e.k)) {
+            if (! isfinite(e->e.k)) {
                 e->op = ERR_;
                 e->e.k = (double) 0;
                 cellerror = CELLERROR;

--- a/src/lex.c
+++ b/src/lex.c
@@ -229,7 +229,7 @@ int yylex() {
             if ((!dateflag && *p=='.') || ret == FNUMBER) {
                 ret = FNUMBER;
                 yylval.fval = strtod(nstart, &p);
-                if (!finite(yylval.fval))
+                if (!isfinite(yylval.fval))
                     ret = K_ERR;
                 else
                     decimal = TRUE;


### PR DESCRIPTION
Addressing https://github.com/andmarti1424/sc-im/issues/120

As mentioned in Linux's `finite(2)`:

_"Note that these functions are obsolete."_

This commit requires _GNU_SOURCE, or another feature level supporting isfinite() to be defined, i.e. this PR depends on #122