### PR TITLE
Simplify Makefile, removing some old options

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,153 +1,43 @@
-# Makefile $Revision: 0.1.2
+name = scim
+NAME = SC-IM
 
+prefix  = /usr/local
+EXDIR   = $(prefix)/bin
+HELPDIR = $(prefix)/share/$(name)
+LIBDIR  = $(prefix)/share/doc/$(name)
+MANDIR  = $(prefix)/man/man1
 
-# Specify the name of the program.
-# All documentation and installation keys on this value.
-name=scim
-NAME=SC-IM
-SNAME := -DSNAME=\"$(name)\"
+# Change these to your liking or use `make CC=gcc` etc
+#CC   = cc
+#YACC = bison -y
+#SED  = sed
 
-# Compiler
-CC=gcc
+LDLIBS += -lm $(shell pkg-config --libs ncursesw)
 
-# The base directory where everything should be installed.  If you're
-# packaging this with an O/S, for example, you'll probably want to change
-# this to /usr.  Otherwise, /usr/local is probably more appropriate, unless
-# you're replacing the vendor-supplied version.
-prefix=/usr
+CFLAGS += -Wall -g
+CFLAGS += $(shell pkg-config --cflags ncursesw)
+CFLAGS += -DSNAME=\"$(NAME)\"
+CFLAGS += -D_GNU_SOURCE
+CFLAGS += -DHELP_PATH=\"$(HELPDIR)\"
+CFLAGS += -DLIBDIR=\"$(LIBDIR)\"
+CFLAGS += -DUSECOLORS
+CFLAGS += -DDFLT_PAGER=\"less\"
+CFLAGS += -DHISTORY_FILE=\".$(name)info\"
+CFLAGS += -DUNDO
+# Up to 1048576
+CFLAGS += -DMAXROWS=65536
+# Used for date formatting with C-d shortcut
+CFLAGS += -DUSELOCALE
 
-# This is where the install step puts it.
-EXDIR=$(prefix)/bin
+# Uncomment for basic XLS import
+#CFLAGS += -DXML
+#LDLIBS += -lxlsreader
 
-# Help dir
-HELPDIR := $(prefix)/share/$(name)
-HELP_PATH := -DHELP_PATH=\"$(HELPDIR)\"
+# Uncomment for basic XSL support
+#CFLAGS += -DXLSX -I/usr/include/libxml2
+#LDLIBS += -lzip -lxml2
 
-# This is where the man page goes.
-MANDIR=$(prefix)/man/man1
-MANEXT=1
-MANMODE=644
-
-# This is where the library file (tutorial) goes.
-#LIBDIR=/usr/local/share/$(name) # reno
-LIBDIR=$(prefix)/share/doc/$(name)
-LIBRARY=-DLIBDIR=\"$(LIBDIR)\"
-
-# For Building SC-IM in LINUX, set LINUX variable below
-LINUX := -DLINUX
-#LINUX :=
-
-# For Building SC-IM in FREEBSD, set FREEBSD variable below
-#FREEBSD := -DFREEBSD
-FREEBSD :=
-
-# For Building SC-IM in NETBSD, set NETBSD variable below
-#NETBSD := -DNETBSD
-NETBSD :=
-
-# For Building SC-IM in MACOSX, set MACOSX variable below
-#MACOSX := -DMACOSX
-MACOSX :=
-
-# Set SIMPLE for lex.c if you don't want arrow keys or lex.c blows up
-#SIMPLE := -DSIMPLE
-
-# Set USELOCALE to use your local d_fmt for converting dates with C-d shortcut.
-# (See DATES INPUT in help for more details).
-# You also should set this flag if you use extended ascii chars.
-USELOCALE := -DUSELOCALE
-
-# Set this if you want SC-IM to have color support
-USECOLORS := -DUSECOLORS
-
-# Set SIGVOID if signal routines are type void.
-# use: SIGVOID=-DSIGVOID for:
-# System 5.3, SunOS 4.X, VMS, BSD4.4 (reno), and ANSI C Compliant systems
-# use: SIGVOID= for:
-#  BSD systems (excluding reno, BSD4.4), and the UNIXPC 'cc'
-SIGVOID := -DSIGVOID
-
-# Set IEEE_MATH if you need setsticky() calls in your signal handlers
-#IEEE_MATH := -DIEEE_MATH
-
-# The -ffloat-store compiler option is necessary for compiling interp.c to
-# prevent spurious "Still changing after x iterations" errors, intermittent
-# problems with the @round function, comparisons failing when they shouldn't,
-# and potentially other similar problems due to FPU registers having greater
-# precision than doubles in memory.  This is known to be necessary for GCC
-# on x86 processors/FPUs, and probably others.
-FLOAT_STORE := -ffloat-store
-
-# Set RINT=-DRINT if you do not have rint() in math.h
-# Set RINT= on/with (they have rint):
-# SunOS 4.0.3c compiler
-# BSD4.4 (reno)
-#RINT := -DRINT
-
-# If your system supports POSIX.2 regular expressions, REGEX should be
-# set to -DREGCOMP.  Otherwise, set REGEX to -DREGCMP if you have the
-# regcmp/regex regular expression routines (most System V based systems
-# do) or to -DRE_COMP if you have the re_comp/re_exec regular expression
-# routines (most BSD based systems do).  If your system has no support for
-# regular expressions, leave REGEX unset.
-#REGEX := -DREGCMP
-#REGEX := -DRE_COMP
-REGEX := -DREGCOMP
-
-# This is the name of a pager like "more".
-#DFLT_PAGER := -DDFLT_PAGER=\"more\"
-DFLT_PAGER := -DDFLT_PAGER=\"less\"
-
-# This is the name of the history file that is looked in your HOME directory
-# If undefined, no history will be saved
-HISTORY_FILE := -DHISTORY_FILE=\".$(name)info\"
-
-# If your system doesn't have notimeout() in curses, define NONOTIMEOUT
-#NO_NOTIMEOUT := -DNONOTIMEOUT
-
-# MS-DOS (and perhaps Windows) needs y_tab instead of the normal y.tab
-#YTAB := y_tab
-YTAB := y.tab
-
-#YACC := bison -y
-SED := sed
-
-# Uncomment below if you want basic XLS import support.
-# Requires libxlsreader.
-# Add -lxlsreader in LDLIBS as well.
-XLS := 
-#XLS := -DXLS
-
-# Uncomment below if you want basic XLSX import support.
-# Requires libzip-dev and libxml2-dev
-# Add -lzip -xml2 to LDLIBS as well.
-# and -I/usr/include/libxml2 or the acording path to the libxml headers, in CFLAGS
-XLSX :=
-#XLSX := -DXLSX
-
-# Set UNDO variable to enable this feature
-#UNDO :=
-UNDO := -DUNDO
-
-# Set the maximum number of rows in sheet
-# Can be set up to 1048576.
-MAXROWS := 65536
-
-#CFLAGS := -O2 -Wall -pipe -g
-CFLAGS := $(LINUX) $(FREEBSD) $(NETBSD) $(MACOSX) -O2 -Wall -pipe -g -I/usr/include/libxml2 $(shell pkg-config --cflags ncursesw)
-CFLAGS := $(CFLAGS) $(USECOLORS) $(USELOCALE) $(UNDO) $(SIGVOID) $(DFLT_PAGER)
-CFLAGS := $(CFLAGS) $(IEEE_MATH) $(RINT) $(REGEX) $(LIBRARY) -DMAXROWS=$(MAXROWS)
-CFLAGS := $(CFLAGS) $(HELP_PATH) $(SNAME) $(NO_NOTIMEOUT) $(SIMPLE) $(XLS) $(XLSX) $(HISTORY_FILE)
-CFLAGS := $(CFLAGS) -D_GNU_SOURCE  # for wcwidth, wcswidth, tm_gmtoff
-
-LDLIBS := -lm $(shell pkg-config --libs ncursesw)
-#LDLIBS := -lm -lncurses -lxlsreader
-#LDLIBS := -lm -lncurses -lxlsreader -lzip -lxml2
-
-OBJS := $(patsubst %.c, %.o, $(wildcard *.c) $(wildcard utils/*.c)) gram.o
-
-# The documents in the Archive
-#DOCS := README torev
+OBJS = $(patsubst %.c, %.o, $(wildcard *.c) $(wildcard utils/*.c)) gram.o
 
 .PHONY : all clean install
 
@@ -173,10 +63,10 @@ $(name) : $(OBJS)
 $(name)qref: sc.h
 	$(CC) $(CFLAGS) $(LDFLAGS) -DQREF $(QREF_FMT) -DSCNAME=\"$(NAME)\" -o $(name)qref help.c $(LDLIBS)
 
-$(OBJS) : $(YTAB).h experres.h statres.h
+$(OBJS) : y.tab.h experres.h statres.h
 
-$(YTAB).h : gram.y gram.c
-	test -f $(YTAB).c && mv $(YTAB).c gram.c
+y.tab.h : gram.y gram.c
+	test -f y.tab.c && mv y.tab.c gram.c
 
 gram.c : gram.y
 	$(YACC) -d $<
@@ -189,9 +79,6 @@ experres.h : gram.y
 
 statres.h : gram.y
 	sed -f sres.sed < gram.y > statres.h
-
-interp.o : interp.c
-	$(CC) $(CFLAGS) $(FLOAT_STORE) -c $< -o $@
 
 clean:
 	rm -f $(OBJS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ CFLAGS += -DMAXROWS=65536
 CFLAGS += -DUSELOCALE
 
 # Uncomment for basic XLS import
-#CFLAGS += -DXML
+#CFLAGS += -DXLS
 #LDLIBS += -lxlsreader
 
 # Uncomment for basic XSL support

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,20 +20,25 @@ CFLAGS += -DSNAME=\"$(NAME)\"
 CFLAGS += -D_GNU_SOURCE
 CFLAGS += -DHELP_PATH=\"$(HELPDIR)\"
 CFLAGS += -DLIBDIR=\"$(LIBDIR)\"
-CFLAGS += -DUSECOLORS
+
+# Sets default pager, e.g. 'less' or 'more'
 CFLAGS += -DDFLT_PAGER=\"less\"
+# Comment out to disable color support
+CFLAGS += -DUSECOLORS
+# Command history file, relative to home directory. Comment out to disable.
 CFLAGS += -DHISTORY_FILE=\".$(name)info\"
+# Comment out to disable undo/redo support
 CFLAGS += -DUNDO
-# Up to 1048576
+# Maximum number of rows in spreadsheet. Up to 1048576
 CFLAGS += -DMAXROWS=65536
 # Used for date formatting with C-d shortcut
 CFLAGS += -DUSELOCALE
 
-# Uncomment for basic XLS import
+# Uncomment for basic XLS import. Requires libxlsreader
 #CFLAGS += -DXLS
 #LDLIBS += -lxlsreader
 
-# Uncomment for basic XSL support
+# Uncomment for basic XSL support. Requires libzip and libxml2
 #CFLAGS += -DXLSX -I/usr/include/libxml2
 #LDLIBS += -lzip -lxml2
 

--- a/src/lex.c
+++ b/src/lex.c
@@ -1,10 +1,6 @@
 #include <sys/types.h>
 #include <string.h>
 
-#ifdef IEEE_MATH
- #include <ieeefp.h>
-#endif /* IEEE_MATH */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <signal.h>
@@ -32,10 +28,6 @@ void fpe_trap(int signo) {
 #if defined(i386)
     asm("    fnclex");
     asm("    fwait");
-#else
- #ifdef IEEE_MATH
-    (void)fpsetsticky((fp_except)0);    /* Clear exception */
- #endif /* IEEE_MATH */
 #endif
     longjmp(fpe_buf, 1);
 }


### PR DESCRIPTION
The variable + `CFLAGS` pattern

    FOO = x
    CFLAGS := $(CFLAGS) -DFOO=$(FOO)

is replaced by updating `CFLAGS` directly:

    CFLAGS += -DFOO=x

This keeps the Makefile a bit shorter and more manageable.

Some other options have been removed because they aren't needed any more, like regex configurations for very old systems and `IEEE_MATH`.

CC is no longer set by the Makefile. It has a default value set by make or the system and can be adjusted in the Makefile or by passing an argument to make: `make CC=clang`

**edit**: forgot to mention, this also removes the OS-specific options and defaults `prefix` to `/usr/local`.