### PR TITLE
_XOPEN_SOURCE_EXTENDED instead of _GNU_SOURCE

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,8 +22,8 @@ LDLIBS += -lm $(shell pkg-config --libs ncursesw)
 
 CFLAGS += -Wall -g
 CFLAGS += $(shell pkg-config --cflags ncursesw)
+CFLAGS += -D_XOPEN_SOURCE_EXTENDED
 CFLAGS += -DSNAME=\"$(NAME)\"
-CFLAGS += -D_GNU_SOURCE
 CFLAGS += -DHELP_PATH=\"$(HELPDIR)\"
 CFLAGS += -DLIBDIR=\"$(LIBDIR)\"
 


### PR DESCRIPTION
ncurses on macOS only declares `cchar_t` if `_XOPEN_SOURCE_EXTENDED` is defined.

Tested to build on FreeBSD 10.3, macOS 10.11 and Ubuntu trusty.

This addresses the `cchar_t` issue encountered in #126