### PR TITLE
Fix XLS importer

### DIFF
--- a/src/xls.c
+++ b/src/xls.c
@@ -59,8 +59,7 @@ int open_xls(char * fname, char * encoding) {
     for (r = 0; r <= pWS->rows.lastrow; r++) { // rows
         for (c = 0; c <= pWS->rows.lastcol; c++) { // cols
             xlsCell * cell = xls_cell(pWS, r, c);
-            //if ((! cell) || (cell->isHidden)) continue;
-            if ((! cell) || (cell->ishiden)) continue; // Unfortunately libxls spells this "ishiden"
+            if ((! cell) || (cell->isHidden)) continue;
 
             // TODO enable rowspan ?
             //if (cell->rowspan > 1) continue;


### PR DESCRIPTION
Contrary to the comment in xls.c, the "isHidden" struct member is actually
spelled "isHidden", even in the latest release version, 1.4.0.
The comment is almost exactly five years out of date now.

Cf. https://sourceforge.net/p/libxls/code/HEAD/tree/trunk/libxls/include/libxls/xlsstruct.h#l430