### PR TITLE
Autodetect XLSX support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -55,9 +55,10 @@ CFLAGS += -DUSELOCALE
 #CFLAGS += -DXLS
 #LDLIBS += -lxlsreader
 
-# Uncomment for basic XLSX support. Requires libzip and libxml2
-#CFLAGS += -DXLSX -I/usr/include/libxml2
-#LDLIBS += -lzip -lxml2
+ifneq ($(shell pkg-config --exists libzip libxml-2.0 || echo 'no'),no)
+CFLAGS += -DXLSX $(shell pkg-config --cflags libxml-2.0 libzip)
+LDLIBS += $(shell pkg-config --libs libxml-2.0 libzip)
+endif
 
 OBJS = $(patsubst %.c, %.o, $(wildcard *.c) $(wildcard utils/*.c)) gram.o
 


### PR DESCRIPTION
Both libzip and libXML have pkg-config files. Exploit this fact
to autodetect whether XLSX support may be compiled.