### PR TITLE
Process $HOME/.scimrc after loading a file

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -38,7 +38,6 @@ extern int yyparse(void);
 /* erase the database (tbl, etc.) */
 void erasedb() {
     int  r, c;
-    char * home;
 
     for (c = 0; c <= maxcol; c++) {
         fwidth[c] = DEFWIDTH;
@@ -74,17 +73,21 @@ void erasedb() {
     optimize = 0;
     currow = curcol = 0;
 
-    // Load $HOME/.scimrc if present.
-    if ((home = getenv("HOME"))) {
-        strcpy(curfile, home);
-        strcat(curfile, "/.scimrc");
-        if ((c = open(curfile, O_RDONLY)) > -1) {
-            close(c);
-            (void) readfile(curfile, 0);
-        }
-    }
+    loadrc();
 
     *curfile = '\0';
+}
+
+void loadrc(void) {
+    char rcpath[PATHLEN];
+    char * home;
+
+    if ((home = getenv("HOME"))) {
+        memset(rcpath, 0, sizeof(rcpath));
+        strncpy(rcpath, home, sizeof(rcpath) - (sizeof("/.scimrc") + 1));
+        strcat(rcpath, "/.scimrc");
+        (void) readfile(rcpath, 0);
+    }
 }
 
 // function that checks if a file exists.

--- a/src/file.h
+++ b/src/file.h
@@ -1,4 +1,5 @@
 void erasedb();
+void loadrc(void);
 int modcheck();
 int savefile();
 int writefile(char *fname, int r0, int c0, int rn, int cn);

--- a/src/main.c
+++ b/src/main.c
@@ -372,6 +372,7 @@ void load_sc() {
         }
         wordfree(&p);
         EvalAll();                                 // we eval formulas
+        loadrc();
     }
     return;
 }


### PR DESCRIPTION
Factor a loadrc() function out of file.c:erasedb(); call it
explicitly after loading a file in main.c:load_sc(). This ensures
$HOME/.scimrc is processed and loaded after the file passed
on the command line is loaded.

Possible fix for #134.