### PR TITLE
Makefile and installation instructions for Ubuntu.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,6 +67,48 @@ brew tap nickolasburr/pfa
 brew install sc-im
 ```
 
+### Ubuntu with XLSX import & export
+
+Start by installing all required dependencies.
+
+```
+$ sudo apt-get install bison libncurses5-dev libncursesw5-dev libxml2-dev libzip-dev
+
+$ git clone https://github.com/jmcnamara/libxlsxwriter.git
+$ cd libxlsxwriter/
+$ make
+$ sudo make install
+```
+
+At this point, it is important to refresh the dynamic link library cache:
+```
+$ sudo ldconfig
+```
+
+Proceed with downloading and compiling sc-im.
+```
+$ cd ..
+$ git clone https://github.com/andmarti1424/sc-im.git
+$ cd sc-im/src
+$ make
+$ sudo make install
+```
+
+Type `scim` at the command line prompt to run the program.
+
+For legacy `.xsl` file reading support, please refer to [this wiki page](https://github.com/andmarti1424/sc-im/wiki/Ubuntu-16.04.1-with-libxlsreader).
+
+### Configuration
+
+The file `~/.scimrc` contains configuration data. Here is an example.
+
+    set autocalc
+    set numeric
+    set numeric_decimal=0
+    set xlsx_readformulas
+    
+Other configuration variables are listed in the [help file](https://raw.githubusercontent.com/andmarti1424/sc-im/freeze/src/doc).
+
 ### Helping us
 
 Want to help?  You can help us with one or more of the following:

--- a/Readme.md
+++ b/Readme.md
@@ -69,34 +69,7 @@ brew install sc-im
 
 ### Ubuntu with XLSX import & export
 
-Start by installing all required dependencies.
-
-```
-$ sudo apt-get install bison libncurses5-dev libncursesw5-dev libxml2-dev libzip-dev
-
-$ git clone https://github.com/jmcnamara/libxlsxwriter.git
-$ cd libxlsxwriter/
-$ make
-$ sudo make install
-```
-
-At this point, it is important to refresh the dynamic link library cache:
-```
-$ sudo ldconfig
-```
-
-Proceed with downloading and compiling sc-im.
-```
-$ cd ..
-$ git clone https://github.com/andmarti1424/sc-im.git
-$ cd sc-im/src
-$ make
-$ sudo make install
-```
-
-Type `scim` at the command line prompt to run the program.
-
-For legacy `.xsl` file reading support, please refer to [this wiki page](https://github.com/andmarti1424/sc-im/wiki/Ubuntu-16.04.1-with-libxlsreader).
+See [this wiki page](https://github.com/andmarti1424/sc-im/wiki/Ubuntu-with-XLSX-import-&-export).
 
 ### Configuration
 
@@ -105,6 +78,7 @@ The file `~/.scimrc` contains configuration data. Here is an example.
     set autocalc
     set numeric
     set numeric_decimal=0
+    set overlap
     set xlsx_readformulas
     
 Other configuration variables are listed in the [help file](https://raw.githubusercontent.com/andmarti1424/sc-im/freeze/src/doc).

--- a/src/Makefile
+++ b/src/Makefile
@@ -77,6 +77,10 @@ ifneq (,$(wildcard /usr/include/xlsxwriter.h))
   CFLAGS += -DXLSX_EXPORT
   LDLIBS += -lxlsxwriter
 endif
+ifneq (,$(wildcard /usr/local/include/xlsxwriter.h))
+  CFLAGS += -DXLSX_EXPORT
+  LDLIBS += -lxlsxwriter
+endif
 
 # Check for gnuplot existance
 ifneq (, $(shell which gnuplot))


### PR DESCRIPTION
Dear Andrés,

Here is a `Makefile` with a couple of lines added for improved GNU/Linux support.
I have also added Ubuntu installation instructions to the `Read.me`.
These instructions will only work with the patched `Makefile`.

With the Ubuntu instructions on a prominent place (the Wiki is often overlooked by many), I hope a whole lot more people will start using sc-im.