### PR TITLE
Always use system ncurses on macOS

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,12 +43,6 @@ SC-IM stands for Spreadsheet Calculator Improvised. :-)
     vim /src/Makefile
 ```
 
-* Only for OSX users who dont use Homebrew:
-```
-    brew install ncurses
-    brew link ncurses
-```
-
 * Inside /src folder run:
 ```
     make

--- a/src/Makefile
+++ b/src/Makefile
@@ -92,7 +92,10 @@ ifneq (, $(shell which pkg-config))
   # Any system with pkg-config
 
   # NOTE: ncursesw (required)
-  ifneq ($(shell pkg-config --exists ncursesw || echo 'no'),no)
+  ifeq ($(shell uname -s),Darwin)
+    # macOS' ncurses is built with wide-char support
+    LDFLAGS += -lncurses
+  else ifneq ($(shell pkg-config --exists ncursesw || echo 'no'),no)
     CFLAGS += $(shell pkg-config --cflags ncursesw)
     LDLIBS += $(shell pkg-config --libs ncursesw)
   else ifneq ($(shell pkg-config --exists ncurses || echo 'no'),no)


### PR DESCRIPTION
Removing the unneeded dependency on Homebrew ncursesw, as macOS system
ncurses also includes wide character support and is compatible with sc-im.

System ncurses is already used for the vanilla build:

  https://github.com/andmarti1424/sc-im/pull/183