### PR TITLE
Don't clobber startup message w/ err opening file

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -583,15 +583,16 @@ void write_cells(register FILE *f, int r0, int c0, int rn, int cn, int dr, int d
 }
 
 /**
- * \brief TODO Document readfile
+ * \brief Try to open a spreadsheet file.
  *
  * \param[in] fname file name
  * \param[in] eraseflg
  *
- * \return none
+ * \return SC_READFILE_SUCCESS if we loaded the file, SC_READFILE_ERROR if we failed,
+ * SC_READFILE_DOESNTEXIST if the file doesn't exist.
  */
 
-int readfile(char * fname, int eraseflg) {
+sc_readfile_result readfile(char * fname, int eraseflg) {
     if (!strlen(fname)) return 0;
     loading = 1;
 
@@ -603,7 +604,7 @@ int readfile(char * fname, int eraseflg) {
             // TODO - force load with '!' ??
             sc_error("There are changes unsaved. Cannot load file: %s", fname);
             loading = 0;
-            return 0;
+            return SC_READFILE_ERROR;
         }
         remove_backup(curfile);
     }
@@ -619,7 +620,7 @@ int readfile(char * fname, int eraseflg) {
                 loading = 0;
                 extern int shall_quit;
                 shall_quit = 1;
-                return 0;
+                return SC_READFILE_ERROR;
                 break;
             case L'e':
                 remove_backup(fname);
@@ -657,7 +658,7 @@ int readfile(char * fname, int eraseflg) {
         modflg = 0;
         #endif
         loading = 0;
-        return 1;
+        return SC_READFILE_SUCCESS;
 
     // If file is an xls file, we import it
     } else if (len > 4 && ! strcasecmp( & fname[len-4], ".xls")){
@@ -669,7 +670,7 @@ int readfile(char * fname, int eraseflg) {
         strcpy(curfile, fname);
         #endif
         loading = 0;
-        return 1;
+        return SC_READFILE_SUCCESS;
 
     // If file is an delimited text file, we import it
     } else if (len > 4 && ( ! strcasecmp( & fname[len-4], ".csv") ||
@@ -693,12 +694,12 @@ int readfile(char * fname, int eraseflg) {
         strcpy(curfile, fname);
         modflg = 0;
         loading = 0;
-        return 1;
+        return SC_READFILE_SUCCESS;
 
     } else {
         sc_info("\"%s\" is not a SC-IM compatible file", fname);
         loading = 0;
-        return 0;
+        return SC_READFILE_ERROR;
     }
 
     // We open an 'sc' format file
@@ -711,7 +712,7 @@ int readfile(char * fname, int eraseflg) {
     if (f == NULL) {
         loading = 0;
         strcpy(curfile, save);
-        return 0;
+        return SC_READFILE_DOESNTEXIST;
     } /* */
 
     if (eraseflg) erasedb();
@@ -732,7 +733,7 @@ int readfile(char * fname, int eraseflg) {
     strcpy(curfile, save);
     EvalAll();
     modflg = 0;
-    return 1;
+    return SC_READFILE_SUCCESS;
 }
 
 /**

--- a/src/file.h
+++ b/src/file.h
@@ -53,7 +53,14 @@ void write_fd(register FILE *f, int r0, int c0, int rn, int cn);
 void write_cells(register FILE *f, int r0, int c0, int rn, int cn, int dr, int dc);
 void write_marks(register FILE *f);
 void write_franges(register FILE *f);
-int readfile(char *fname, int eraseflg);
+
+typedef enum {
+    SC_READFILE_ERROR = 0,
+    SC_READFILE_SUCCESS = 1,
+    SC_READFILE_DOESNTEXIST = 2
+} sc_readfile_result;
+sc_readfile_result readfile(char *fname, int eraseflg);
+
 int file_exists(const char * fname);
 char * findhome(char *path);
 int backup_file(char *path);

--- a/src/main.c
+++ b/src/main.c
@@ -560,8 +560,16 @@ void load_sc() {
         if (c) sprintf(word + strlen(word), " ");
         sprintf(word + strlen(word), "%s", p.we_wordv[c]);
     }
-    if (strlen(word) && ! readfile(word, 0) && ! atoi((char *) get_conf_value("nocurses"))) {
-        sc_info("New file: \"%s\"", word);     // file passed to scim executable does not exists
+    if (strlen(word) != 0) {
+        sc_readfile_result result = readfile(word, 0);
+        if (!atoi((char *) get_conf_value("nocurses"))) {
+            if (result == SC_READFILE_DOESNTEXIST) {
+                // It's a new record!
+                sc_info("New file: \"%s\"", word);
+            } else if (result == SC_READFILE_ERROR) {
+                sc_info("\"%s\" is not a SC-IM compatible file", word);
+            }
+        }
     }
     wordfree(&p);
     return;


### PR DESCRIPTION
When we opened a file with an unrecognized extension, this was reported
as the same type of failure as if you had specified a file that didn't
exist. The "this is a new file" message clobbered the "failed to read
this file" message.

Fixes #250