### PR TITLE
Allow for lua scripts in local .sc directory

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,6 +53,16 @@ SC-IM stands for Spreadsheet Calculator Improvised. :-)
     make -C src install
 ```
 
+### Building on OS X
+
+You can follow the instructions as above, but if you would like Lua scripting
+support, you will need to install Lua 5.1, which you can do with,
+
+```
+    brew install lua@5.1
+```
+
+And then follow the instructions as above.
 
 ### Homebrew for OSX users
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,19 +2,19 @@
 name = sc-im
 
 # The base directory where everything should be installed.
-prefix	= /usr/local
+prefix  = /usr/local
 
-EXDIR		= $(prefix)/bin
+EXDIR   = $(prefix)/bin
 HELPDIR = $(prefix)/share/$(name)
-LIBDIR	= $(prefix)/share/doc/$(name)
+LIBDIR  = $(prefix)/share/doc/$(name)
 
 # This is where the man page goes.
-MANDIR	= $(prefix)/share/man/man1
+MANDIR  = $(prefix)/share/man/man1
 
 # Change these to your liking or use `make CC=gcc` etc
-#CC		= cc
+#CC   = cc
 #YACC = bison -y
-#SED	= sed
+#SED  = sed
 
 LDLIBS += -lm
 
@@ -69,70 +69,66 @@ CFLAGS += -DAUTOBACKUP
 CFLAGS += -DHAVE_PTHREAD
 
 ifneq ($(shell uname -s),Darwin)
-	LDLIBS += -pthread
+  LDLIBS += -pthread
 endif
 
 # NOTE: libxlsxwriter is required for xlsx file export support
 ifneq (,$(wildcard /usr/include/xlsxwriter.h))
-	CFLAGS += -DXLSX_EXPORT
-	LDLIBS += -lxlsxwriter
+  CFLAGS += -DXLSX_EXPORT
+  LDLIBS += -lxlsxwriter
 endif
 ifneq (,$(wildcard /usr/local/include/xlsxwriter.h))
-	CFLAGS += -DXLSX_EXPORT
-	LDLIBS += -lxlsxwriter
+  CFLAGS += -DXLSX_EXPORT
+  LDLIBS += -lxlsxwriter
 endif
 
 # Check for gnuplot existance
 ifneq (, $(shell which gnuplot))
-	CFLAGS += -DGNUPLOT
+  CFLAGS += -DGNUPLOT
 endif
 
 # dynamic linking (should not be used in FreeBSD
 ifneq ($(shell uname -s),FreeBSD)
-	LDLIBS += -ldl
+  LDLIBS += -ldl
 endif
 
 ifneq (, $(shell which pkg-config))
-	# Any system with pkg-config
+  # Any system with pkg-config
 
-	# NOTE: ncursesw (required)
-	ifeq ($(shell uname -s),Darwin)
-		# macOS' ncurses is built with wide-char support
-		LDFLAGS += -lncurses
-	else ifneq ($(shell pkg-config --exists ncursesw || echo 'no'),no)
-		CFLAGS += $(shell pkg-config --cflags ncursesw)
-		LDLIBS += $(shell pkg-config --libs ncursesw)
-	else ifneq ($(shell pkg-config --exists ncurses || echo 'no'),no)
-		# hopefully this includes wide character support then
-		CFLAGS += $(shell pkg-config --cflags ncurses)
-		LDLIBS += $(shell pkg-config --libs ncurses)
-	else
-		LDLIBS += -lncursesw
-	endif
+  # NOTE: ncursesw (required)
+  ifeq ($(shell uname -s),Darwin)
+    # macOS' ncurses is built with wide-char support
+    LDFLAGS += -lncurses
+  else ifneq ($(shell pkg-config --exists ncursesw || echo 'no'),no)
+    CFLAGS += $(shell pkg-config --cflags ncursesw)
+    LDLIBS += $(shell pkg-config --libs ncursesw)
+  else ifneq ($(shell pkg-config --exists ncurses || echo 'no'),no)
+    # hopefully this includes wide character support then
+    CFLAGS += $(shell pkg-config --cflags ncurses)
+    LDLIBS += $(shell pkg-config --libs ncurses)
+  else
+    LDLIBS += -lncursesw
+  endif
 
-	# NOTE: libxml and libzip are required for xlsx file import support
-	ifneq ($(shell pkg-config --exists libzip libxml-2.0 || echo 'no'),no)
-		CFLAGS += -DXLSX $(shell pkg-config --cflags libxml-2.0 libzip)
-		LDLIBS += $(shell pkg-config --libs libxml-2.0 libzip)
-	endif
+  # NOTE: libxml and libzip are required for xlsx file import support
+  ifneq ($(shell pkg-config --exists libzip libxml-2.0 || echo 'no'),no)
+    CFLAGS += -DXLSX $(shell pkg-config --cflags libxml-2.0 libzip)
+    LDLIBS += $(shell pkg-config --libs libxml-2.0 libzip)
+  endif
 
-	# NOTE: lua support
-	ifneq ($(shell pkg-config --exists lua51 || echo 'no'),no)
-		CFLAGS += -DXLUA $(shell pkg-config --cflags lua51)
-		LDLIBS += $(shell pkg-config --libs lua51) -Wl,--export-dynamic
-	else ifneq ($(shell pkg-config --exists lua-5.1 || echo 'no'),no) # FreeBSD
-		CFLAGS += -DXLUA $(shell pkg-config --cflags lua-5.1)
-		ifneq ($(shell uname -s),Darwin)
-			LDLIBS += $(shell pkg-config --libs lua-5.1) -Wl,--export-dynamic
-		else
-			LDLIBS += $(shell pkg-config --libs lua-5.1) -rdynamic
-		endif
-	endif
+  # NOTE: lua support
+  ifneq ($(shell pkg-config --exists lua51 || echo 'no'),no)
+    CFLAGS += -DXLUA $(shell pkg-config --cflags lua51)
+    LDLIBS += $(shell pkg-config --libs lua51) -Wl,--export-dynamic
+  else ifneq ($(shell pkg-config --exists lua-5.1 || echo 'no'),no) # FreeBSD
+    CFLAGS += -DXLUA $(shell pkg-config --cflags lua-5.1)
+    LDLIBS += $(shell pkg-config --libs lua-5.1) -Wl,--export-dynamic
+  endif
 else ifeq ($(shell uname -s),Darwin)
-	# macOS without pkg-config
+  # macOS without pkg-config
 
-	# macOS' ncurses is built with wide-char support
-	LDFLAGS += -lncurses
+  # macOS' ncurses is built with wide-char support
+  LDFLAGS += -lncurses
 endif
 
 OBJS = $(patsubst %.c, %.o, $(wildcard *.c) $(wildcard utils/*.c)) gram.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,19 +2,19 @@
 name = sc-im
 
 # The base directory where everything should be installed.
-prefix  = /usr/local
+prefix	= /usr/local
 
-EXDIR   = $(prefix)/bin
+EXDIR		= $(prefix)/bin
 HELPDIR = $(prefix)/share/$(name)
-LIBDIR  = $(prefix)/share/doc/$(name)
+LIBDIR	= $(prefix)/share/doc/$(name)
 
 # This is where the man page goes.
-MANDIR  = $(prefix)/share/man/man1
+MANDIR	= $(prefix)/share/man/man1
 
 # Change these to your liking or use `make CC=gcc` etc
-#CC   = cc
+#CC		= cc
 #YACC = bison -y
-#SED  = sed
+#SED	= sed
 
 LDLIBS += -lm
 
@@ -69,66 +69,70 @@ CFLAGS += -DAUTOBACKUP
 CFLAGS += -DHAVE_PTHREAD
 
 ifneq ($(shell uname -s),Darwin)
-  LDLIBS += -pthread
+	LDLIBS += -pthread
 endif
 
 # NOTE: libxlsxwriter is required for xlsx file export support
 ifneq (,$(wildcard /usr/include/xlsxwriter.h))
-  CFLAGS += -DXLSX_EXPORT
-  LDLIBS += -lxlsxwriter
+	CFLAGS += -DXLSX_EXPORT
+	LDLIBS += -lxlsxwriter
 endif
 ifneq (,$(wildcard /usr/local/include/xlsxwriter.h))
-  CFLAGS += -DXLSX_EXPORT
-  LDLIBS += -lxlsxwriter
+	CFLAGS += -DXLSX_EXPORT
+	LDLIBS += -lxlsxwriter
 endif
 
 # Check for gnuplot existance
 ifneq (, $(shell which gnuplot))
-  CFLAGS += -DGNUPLOT
+	CFLAGS += -DGNUPLOT
 endif
 
 # dynamic linking (should not be used in FreeBSD
 ifneq ($(shell uname -s),FreeBSD)
-  LDLIBS += -ldl
+	LDLIBS += -ldl
 endif
 
 ifneq (, $(shell which pkg-config))
-  # Any system with pkg-config
+	# Any system with pkg-config
 
-  # NOTE: ncursesw (required)
-  ifeq ($(shell uname -s),Darwin)
-    # macOS' ncurses is built with wide-char support
-    LDFLAGS += -lncurses
-  else ifneq ($(shell pkg-config --exists ncursesw || echo 'no'),no)
-    CFLAGS += $(shell pkg-config --cflags ncursesw)
-    LDLIBS += $(shell pkg-config --libs ncursesw)
-  else ifneq ($(shell pkg-config --exists ncurses || echo 'no'),no)
-    # hopefully this includes wide character support then
-    CFLAGS += $(shell pkg-config --cflags ncurses)
-    LDLIBS += $(shell pkg-config --libs ncurses)
-  else
-    LDLIBS += -lncursesw
-  endif
+	# NOTE: ncursesw (required)
+	ifeq ($(shell uname -s),Darwin)
+		# macOS' ncurses is built with wide-char support
+		LDFLAGS += -lncurses
+	else ifneq ($(shell pkg-config --exists ncursesw || echo 'no'),no)
+		CFLAGS += $(shell pkg-config --cflags ncursesw)
+		LDLIBS += $(shell pkg-config --libs ncursesw)
+	else ifneq ($(shell pkg-config --exists ncurses || echo 'no'),no)
+		# hopefully this includes wide character support then
+		CFLAGS += $(shell pkg-config --cflags ncurses)
+		LDLIBS += $(shell pkg-config --libs ncurses)
+	else
+		LDLIBS += -lncursesw
+	endif
 
-  # NOTE: libxml and libzip are required for xlsx file import support
-  ifneq ($(shell pkg-config --exists libzip libxml-2.0 || echo 'no'),no)
-    CFLAGS += -DXLSX $(shell pkg-config --cflags libxml-2.0 libzip)
-    LDLIBS += $(shell pkg-config --libs libxml-2.0 libzip)
-  endif
+	# NOTE: libxml and libzip are required for xlsx file import support
+	ifneq ($(shell pkg-config --exists libzip libxml-2.0 || echo 'no'),no)
+		CFLAGS += -DXLSX $(shell pkg-config --cflags libxml-2.0 libzip)
+		LDLIBS += $(shell pkg-config --libs libxml-2.0 libzip)
+	endif
 
-  # NOTE: lua support
-  ifneq ($(shell pkg-config --exists lua51 || echo 'no'),no)
-    CFLAGS += -DXLUA $(shell pkg-config --cflags lua51)
-    LDLIBS += $(shell pkg-config --libs lua51) -Wl,--export-dynamic
-  else ifneq ($(shell pkg-config --exists lua-5.1 || echo 'no'),no) # FreeBSD
-    CFLAGS += -DXLUA $(shell pkg-config --cflags lua-5.1)
-    LDLIBS += $(shell pkg-config --libs lua-5.1) -Wl,--export-dynamic
-  endif
+	# NOTE: lua support
+	ifneq ($(shell pkg-config --exists lua51 || echo 'no'),no)
+		CFLAGS += -DXLUA $(shell pkg-config --cflags lua51)
+		LDLIBS += $(shell pkg-config --libs lua51) -Wl,--export-dynamic
+	else ifneq ($(shell pkg-config --exists lua-5.1 || echo 'no'),no) # FreeBSD
+		CFLAGS += -DXLUA $(shell pkg-config --cflags lua-5.1)
+		ifneq ($(shell uname -s),Darwin)
+			LDLIBS += $(shell pkg-config --libs lua-5.1) -Wl,--export-dynamic
+		else
+			LDLIBS += $(shell pkg-config --libs lua-5.1) -rdynamic
+		endif
+	endif
 else ifeq ($(shell uname -s),Darwin)
-  # macOS without pkg-config
+	# macOS without pkg-config
 
-  # macOS' ncurses is built with wide-char support
-  LDFLAGS += -lncurses
+	# macOS' ncurses is built with wide-char support
+	LDFLAGS += -lncurses
 endif
 
 OBJS = $(patsubst %.c, %.o, $(wildcard *.c) $(wildcard utils/*.c)) gram.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -122,7 +122,11 @@ ifneq (, $(shell which pkg-config))
     LDLIBS += $(shell pkg-config --libs lua51) -Wl,--export-dynamic
   else ifneq ($(shell pkg-config --exists lua-5.1 || echo 'no'),no) # FreeBSD
     CFLAGS += -DXLUA $(shell pkg-config --cflags lua-5.1)
-    LDLIBS += $(shell pkg-config --libs lua-5.1) -Wl,--export-dynamic
+    ifneq ($(shell uname -s),Darwin)
+      LDLIBS += $(shell pkg-config --libs lua-5.1) -Wl,--export-dynamic
+    else
+      LDLIBS += $(shell pkg-config --libs lua-5.1) -rdynamic
+    endif
   endif
 else ifeq ($(shell uname -s),Darwin)
   # macOS without pkg-config

--- a/src/doc
+++ b/src/doc
@@ -791,7 +791,7 @@ Commands for handling cell content:
                 available for dynamic linking with modules.
 
                 The search path for LUA trigger files is
-                $HOME/.scim/lua/ or /usr/local/share/scim/lua
+                $PWD/lua/ or $HOME/.scim/lua/ or /usr/local/share/scim/lua
                 (in that order) and for C Trigger
                 $HOME/.scim/module or /usr/local/share/scim/module
 
@@ -1284,7 +1284,7 @@ Commands for handling cell content:
     @lua("luascript",0)
         Executes a "luascript". Using Lua script scim can be extend with lot
         new functionality, such as complex programming, accessing databases etc.
-        The search patch for LUA scripts files is
+        The search patch for LUA scripts files is $PWD/lua/
         $HOME/.scim/lua/ or /usr/local/share/scim/lua (in that order)
         Always use it only with @ston see example:
         @ston(@lua("luascript",0))
@@ -1354,7 +1354,7 @@ Commands for handling cell content:
      sc.curcol()             - return current column
      sc.currow()             - return current row
 
-     The search patch for LUA scripts files is
+     The search patch for LUA scripts files is $PWD/lua or
      $HOME/.scim/lua/ or /usr/local/share/scim/lua (in that order)
      Example can be found in sc-im/examples/lua in source code tree.
 

--- a/src/file.c
+++ b/src/file.c
@@ -1339,7 +1339,17 @@ int max_length(FILE * f) {
 int plugin_exists(char * name, int len, char * path) {
     FILE * fp;
     static char * HomeDir;
+    char cwd[1024];
 
+    if (getcwd(cwd, sizeof(cwd)) != NULL) {
+        strcpy((char *) path, cwd);
+        strcat((char *) path, "/");
+        strncat((char *) path, name, len);
+        if ((fp = fopen((char *) path, "r"))) {
+            fclose(fp);
+            return 1;
+        }
+    }
     if ((HomeDir = getenv("HOME"))) {
         strcpy((char *) path, HomeDir);
         strcat((char *) path, "/.scim/");


### PR DESCRIPTION
```sh
# Make a new project directory
mkdir sc-im-test
cd sc-im-test

# Add the lua script
mkdir lua
echo 'function trg(c,r)' >> lua/test.lua
echo '  sc.lsetstr(1,1,"String From Lua")' >> lua/test.lua
echo '  sc.sc("LET A2=5")' >> lua/test.lua
echo 'end' >> lua/test.lua

# Add the spreadsheet
echo 'set external_functions' >> test.sc
echo 'trigger a5 "mode=W type=LUA file=test.lua function=trg"' >> test.sc
echo 'goto A1' >> test.sc

# Finally, open the spreadsheet with `../sc-im/src/sc-im test.sc` or similar,
# and modify cell A5 to make sure Lua is called.
```

Open `path/to/sc-im test.sc` and change cell A5. This will trigger the lua script to run.

In order to get Lua support working on OS X, the compiler flags needed to be changed slightly. `-Wl,--export-dynamic` is not supported, `-rdynamic` must be used instead.