### PR TITLE
Send informational messages to stderr rather than the output when used in non-interactive mode

### DIFF
--- a/src/macros.h
+++ b/src/macros.h
@@ -103,10 +103,12 @@
 #define CELL_NEGATIVE     17
 #define DEFAULT           18
 #define DEBUG_MSG         19
+#define VALUE_MSG         20
 
 void ui_sc_msg(char * s, int type, ...);
 #define sc_error(x, ...)     ui_sc_msg(x, ERROR_MSG, ##__VA_ARGS__)
 #define sc_debug(x, ...)     ui_sc_msg(x, DEBUG_MSG, ##__VA_ARGS__)
 #define sc_info(x, ...)      ui_sc_msg(x, INFO_MSG, ##__VA_ARGS__)
+#define sc_value(x, ...)     ui_sc_msg(x, VALUE_MSG, ##__VA_ARGS__)
 
 #define RUNTIME ((current_tv.tv_sec - startup_tv.tv_sec) * 1000L + (current_tv.tv_usec - startup_tv.tv_usec) / 1000L)

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -83,7 +83,7 @@ void getnum(int r0, int c0, int rn, int cn, FILE * fd) {
                     sprintf(line, "%.15g", p->v);
                 }
             }
-            sc_info("%s", line);
+            sc_value("%s", line);
             if (brokenpipe) {
                 linelim = -1;
                 return;
@@ -106,7 +106,7 @@ void getnum(int r0, int c0, int rn, int cn, FILE * fd) {
 void getformat(int col, FILE * fd) {
     sprintf(line, "%d %d %d\n", fwidth[col], precision[col], realfmt[col]);
     //write(fd, line, strlen(line));
-    sc_info("%s", line);
+    sc_value("%s", line);
     linelim = -1;
 }
 
@@ -130,7 +130,7 @@ void getfmt(int r0, int c0, int rn, int cn, FILE * fd) {
         for (c = c0, pp = ATBL(tbl, r, c); c <= cn; pp++, c++) {
             *line = '\0';
             if (*pp && (*pp)->format) sprintf(line, "%s", (*pp)->format);
-            sc_info("%s", line);
+            sc_value("%s", line);
             if (brokenpipe) {
                 linelim = -1;
                 return;
@@ -161,7 +161,7 @@ void getstring(int r0, int c0, int rn, int cn, FILE * fd) {
             *line = '\0';
             if (*pp && (*pp)->label)
                 sprintf(line, "%s", (*pp)->label);
-            sc_info("%s", line);
+            sc_value("%s", line);
             if (brokenpipe) {
                 linelim = -1;
                 return;
@@ -199,7 +199,7 @@ void getexp(int r0, int c0, int rn, int cn, FILE * fd) {
                 if (*line == '?')
                     *line = '\0';
             }
-            sc_info("%s", line);
+            sc_value("%s", line);
             if (brokenpipe) {
                 linelim = -1;
                 return;

--- a/src/tui.c
+++ b/src/tui.c
@@ -239,9 +239,9 @@ void ui_sc_msg(char * s, int type, ...) {
         }
         wrefresh(input_win);
 
-    } else if (get_conf_value("output") != NULL && fdoutput != NULL) {
+    } else if (type == VALUE_MSG && get_conf_value("output") != NULL && fdoutput != NULL) {
         fwprintf(fdoutput, L"%s\n", t);
-    } else {
+    } else if (type == VALUE_MSG) {
         if (fwide(stdout, 0) >0)
             //wprintf(L"wide %s\n", t);
             wprintf(L"%s\n", t);
@@ -249,6 +249,14 @@ void ui_sc_msg(char * s, int type, ...) {
             //printf("nowide %s\n", t);
             printf("%s\n", t);
         fflush(stdout);
+    } else {
+        if (fwide(stderr, 0) >0)
+            //wprintf(L"wide %s\n", t);
+            fwprintf(stderr, L"%s\n", t);
+        else
+            //printf("nowide %s\n", t);
+            fprintf(stderr, "%s\n", t);
+        fflush(stderr);
     }
     va_end(args);
     return;


### PR DESCRIPTION
Currently, the non-interactive mode outputs to standard output (or output file) both informational messages and calculated values (getnum, getfmt).

This PR separates those two types, and send only calculated values to output while sending to standard error the informational messages.