### PR TITLE
OpenBSD support (mostly wordexp() workaround)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -92,6 +92,11 @@ ifneq ($(shell uname -s),FreeBSD)
   LDLIBS += -ldl
 endif
 
+# OpenBSD does not implement wordexp()
+ifeq ($(shell uname -s),OpenBSD)
+  CFLAGS += -DNO_WORDEXP
+endif
+
 ifneq (, $(shell which pkg-config))
   # Any system with pkg-config
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -87,9 +87,11 @@ ifneq (, $(shell which gnuplot))
   CFLAGS += -DGNUPLOT
 endif
 
-# dynamic linking (should not be used in FreeBSD
+# dynamic linking (not available in FreeBSD and OpenBSD)
 ifneq ($(shell uname -s),FreeBSD)
-  LDLIBS += -ldl
+  ifneq ($(shell uname -s),OpenBSD)
+    LDLIBS += -ldl
+  endif
 endif
 
 # OpenBSD does not implement wordexp()

--- a/src/cmds_command.c
+++ b/src/cmds_command.c
@@ -439,7 +439,7 @@ void do_commandmode(struct block * sb) {
                     sc_error("File path too long");
                     wordfree(&p);
                 } else {
-                    strncpy(name, p.we_wordv[0], len+1);
+                    memcpy(name, p.we_wordv[0], len+1);
                     name_ok = 1;
                     wordfree(&p);
                 }
@@ -877,7 +877,7 @@ void do_commandmode(struct block * sb) {
                 sc_error("File path too long");
                 wordfree(&p);
             } else {
-                strncpy(name, p.we_wordv[0], len+1);
+                memcpy(name, p.we_wordv[0], len+1);
                 name_ok = 1;
                 wordfree(&p);
             }

--- a/src/cmds_command.c
+++ b/src/cmds_command.c
@@ -412,6 +412,7 @@ void do_commandmode(struct block * sb) {
             int name_ok = 0;
             int force_rewrite = 0;
             #ifndef NO_WORDEXP
+            size_t len;
             wordexp_t p;
             #endif
 
@@ -433,11 +434,12 @@ void do_commandmode(struct block * sb) {
                 wordexp(name, &p, 0);
                 if ( p.we_wordc < 1 ) {
                     sc_error("Failed expanding filepath");
-                } else if ( strlcpy(name, p.we_wordv[0], sizeof(name))
-                               >= sizeof(name) ) {
+
+                } else if ( (len = strlen(p.we_wordv[0])) >= sizeof(name) ) {
                     sc_error("File path too long");
                     wordfree(&p);
                 } else {
+                    strncpy(name, p.we_wordv[0], len+1);
                     name_ok = 1;
                     wordfree(&p);
                 }
@@ -858,6 +860,7 @@ void do_commandmode(struct block * sb) {
             char name [BUFFERSIZE];
             int name_ok = 0;
             #ifndef NO_WORDEXP
+            size_t len;
             wordexp_t p;
             #endif
 
@@ -870,11 +873,11 @@ void do_commandmode(struct block * sb) {
             wordexp(name, &p, 0);
             if ( p.we_wordc < 1 ) {
                 sc_error("Failed to expand filename");
-            } else if ( strlcpy(name, p.we_wordv[0], sizeof(name))
-                            >= sizeof(name) ) {
+            } else if ( (len = strlen(p.we_wordv[0])) >= sizeof(name) ) {
                 sc_error("File path too long");
                 wordfree(&p);
             } else {
+                strncpy(name, p.we_wordv[0], len+1);
                 name_ok = 1;
                 wordfree(&p);
             }

--- a/src/cmds_command.c
+++ b/src/cmds_command.c
@@ -430,6 +430,7 @@ void do_commandmode(struct block * sb) {
                 #ifdef NO_WORDEXP
                 name_ok = 1;
                 #else
+                wordexp(name, &p, 0);
                 if ( p.we_wordc < 1 ) {
                     sc_error("Failed expanding filepath");
                 } else if ( strlcpy(name, p.we_wordv[0], sizeof(name))

--- a/src/file.c
+++ b/src/file.c
@@ -206,7 +206,7 @@ int savefile() {
 
     #ifndef NO_WORDEXP
     wordexp(name, &p, 0);
-    if (pe.we_wordc < 1) {
+    if (p.we_wordc < 1) {
         sc_error("Failed expanding filepath");
         return -1;
     } else if (strlcpy(name, p.we_wordv[0], sizeof(name)) >= sizeof(name)) {

--- a/src/file.c
+++ b/src/file.c
@@ -216,7 +216,7 @@ int savefile() {
         wordfree(&p);
         return -1;
     }
-    strncpy(name, p.we_wordv[0], len+1);
+    memcpy(name, p.we_wordv[0], len+1);
     wordfree(&p);
     #endif
 

--- a/src/file.c
+++ b/src/file.c
@@ -53,7 +53,10 @@
 #include <unistd.h>
 #include <wchar.h>
 #include <sys/wait.h>
+
+#ifndef NO_WORDEXP
 #include <wordexp.h>
+#endif
 
 #include "conf.h"
 #include "maps.h"
@@ -187,8 +190,9 @@ int modcheck() {
 int savefile() {
     int force_rewrite = 0;
     char name[BUFFERSIZE];
+    #ifndef NO_WORDEXP
     wordexp_t p;
-
+    #endif
 
     if (! curfile[0] && wcslen(inputline) < 3) { // casos ":w" ":w!" ":x" ":x!"
         sc_error("There is no filename");
@@ -198,13 +202,23 @@ int savefile() {
     if (inputline[1] == L'!') force_rewrite = 1;
 
     wcstombs(name, inputline, BUFFERSIZE);
-
     del_range_chars(name, 0, 1 + force_rewrite);
-    wordexp(name, &p, 0);
 
-    if (! force_rewrite && p.we_wordv[0] && file_exists(p.we_wordv[0])) {
-        sc_error("File already exists. Use \"!\" to force rewrite.");
+    #ifndef NO_WORDEXP
+    wordexp(name, &p, 0);
+    if (pe.we_wordc < 1) {
+        sc_error("Failed expanding filepath");
+        return -1;
+    } else if (strlcpy(name, p.we_wordv[0], sizeof(name)) >= sizeof(name)) {
+        sc_error("File path too long");
         wordfree(&p);
+        return -1;
+    }
+    wordfree(&p);
+    #endif
+
+    if (! force_rewrite && file_exists(name)) {
+        sc_error("File already exists. Use \"!\" to force rewrite.");
         return -1;
     }
 
@@ -216,18 +230,17 @@ int savefile() {
     // check if backup of newfilename exists.
     // if it exists and '!' is set, remove it.
     // if it exists and no '!' is set, return.
-    if (!strlen(curfile) && backup_exists(p.we_wordv[0])) {
+    if (!strlen(curfile) && backup_exists(name)) {
         if (!force_rewrite) {
-            sc_error("Backup file of %s exists. Use \"!\" to force the write process.", p.we_wordv[0]);
-            wordfree(&p);
+            sc_error("Backup file of %s exists. Use \"!\" to force the write process.", name);
             return -1;
-        } else remove_backup(p.we_wordv[0]);
+        } else remove_backup(name);
     }
     #endif
 
     // copy newfilename to curfile
     if (wcslen(inputline) > 2) {
-        strcpy(curfile, p.we_wordv[0]);
+        strcpy(curfile, name);
     }
 
     // add sc extension if not present
@@ -239,23 +252,19 @@ int savefile() {
     } else if (strlen(curfile) > 4 && (! strcasecmp( & curfile[strlen(curfile)-4], ".csv"))) {
         export_delim(curfile, ',', 0, 0, maxrow, maxcol, 1);
         modflg = 0;
-        wordfree(&p);
         return 0;
     // treat tab
     } else if (strlen(curfile) > 4 && (! strcasecmp( & curfile[strlen(curfile)-4], ".tsv") ||
         ! strcasecmp( & curfile[strlen(curfile)-4], ".tab"))){
         export_delim(curfile, '\t', 0, 0, maxrow, maxcol, 1);
         modflg = 0;
-        wordfree(&p);
         return 0;
     }
     // save in sc format
     if (writefile(curfile, 0, 0, maxrow, maxcol, 1) < 0) {
         sc_error("File could not be saved");
-        wordfree(&p);
         return -1;
     }
-    wordfree(&p);
     return 0;
 }
 

--- a/src/file.c
+++ b/src/file.c
@@ -191,6 +191,7 @@ int savefile() {
     int force_rewrite = 0;
     char name[BUFFERSIZE];
     #ifndef NO_WORDEXP
+    size_t len;
     wordexp_t p;
     #endif
 
@@ -209,11 +210,13 @@ int savefile() {
     if (p.we_wordc < 1) {
         sc_error("Failed expanding filepath");
         return -1;
-    } else if (strlcpy(name, p.we_wordv[0], sizeof(name)) >= sizeof(name)) {
+    }
+    if ((len = strlen(p.we_wordv[0])) >= sizeof(name)) {
         sc_error("File path too long");
         wordfree(&p);
         return -1;
     }
+    strncpy(name, p.we_wordv[0], len+1);
     wordfree(&p);
     #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -555,16 +555,19 @@ void read_argv(int argc, char ** argv) {
 
 void load_sc() {
     char name[PATHLEN];
+    #ifdef NO_WORDEXP
+    size_t len;
+    #else
     int c;
-    #ifndef NO_WORDEXP
     wordexp_t p;
     #endif
 
     #ifdef NO_WORDEXP
-    if (strlcpy(name, loadingfile, sizeof(name)) >= sizeof(name)) {
+    if ((len = strlen(loadingfile)) >= sizeof(name)) {
         sc_info("File path too long: '%s'", loadingfile);
         return;
     }
+    memcpy(name, loadingfile, len+1);
     #else
     wordexp(loadingfile, &p, 0);
     for (c=0; c < p.we_wordc; c++) {


### PR DESCRIPTION
This PR adds OpenBSD support.

The main obstacle is OpenBSD's [lack](http://openbsd-archive.7691.n7.nabble.com/patch-libc-wordexp-support-td159368.html) of `wordexp()`. This is handled by adding support for a `NO_WORDEXP` macro. When defined (only on OpenBSD for now), shell expansion is simply skipped.

The only other change is not adding `-ldl`, as on FreeBSD.
