### PR TITLE
Link ncursesw by default if not using pkg-config

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -133,6 +133,8 @@ else ifeq ($(shell uname -s),Darwin)
 
   # macOS' ncurses is built with wide-char support
   LDFLAGS += -lncurses
+else
+  LDFLAGS += -lncursesw
 endif
 
 OBJS = $(patsubst %.c, %.o, $(wildcard *.c) $(wildcard utils/*.c)) gram.o


### PR DESCRIPTION
If `pkg-config` wasn't available `ncurses` would only be linked on macOS. This commit adds a fallback case to link `ncursesw` by default.