### PR TITLE
Patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.o
+src/y.tab.h
+src/experres.h
+src/gram.c
+src/sc-im
+src/statres.h

--- a/examples/Module/module.c
+++ b/examples/Module/module.c
@@ -16,7 +16,6 @@
 #include "utils/string.h"
 #include "range.h"
 #include "color.h"
-#include "screen.h"
 #include "undo.h"
 #include "conf.h"
 #include "cmds.h"

--- a/examples/Module/module.c
+++ b/examples/Module/module.c
@@ -6,6 +6,8 @@
 
   on the trigger the ent structure is passed and whether the trigger was on Write or on Read. Write trigger, when it was written to selected cells,
   or Read from selected cells.
+
+  Trigger functions return non-zero return value on error.
 */
 
 #include <stdio.h>

--- a/examples/Module/module2.c
+++ b/examples/Module/module2.c
@@ -1,0 +1,73 @@
+/*
+  Trigger example2 in C (Directly calling sc-im code from trigger)
+  to compile
+  gcc -I<path/to/scim/src> -shared -fPIC -o module2.so -g -Wall module2.c
+
+  Copy the resulting module2.so somewhere on the search path, into
+  $HOME/.scim/module or /usr/local/share/scim/module.
+
+  Open sc-im and activate the trigger with the command
+  :trigger a0:a10 "mode=W type=C file=module2.so function=trig_invert"
+
+  Once the trigger has been activated modifying any cell in the specified
+  range (a0:a10), will invoke the trigger function defined below.
+
+  This example trigger function retrieves the new value of the cell and
+  writes a corresponding value to the adjecent cell. If you enter a number
+  into the cell, the value written to the adjecent cell will be its negative,
+  and if you enter a string the value will be the reverse of that string.
+
+*/
+
+#include <stdio.h>
+
+#include "sc.h"
+#include "xmalloc.h"
+#include "trigger.h"
+
+// These functions are part of sc-im itself, and are only visible to the
+// dynamic linker if sc-im has been compiled with "-Wl,--export-dynamic"
+extern void label(register struct ent * v, register char * s, int flushdir);
+extern struct ent *lookat(int row, int col);
+
+static char* strrev(char* s) {
+    int i;
+    char *res;
+    int slen = strlen(s);
+
+    res = scxmalloc(slen+1);
+    if(!res) return NULL;
+    res[slen]=0;
+    for (i=0;i<slen;i++) {
+        res[slen-1-i] = s[i];
+    }
+    return res;
+}
+
+int trig_invert(struct ent *p , int rw) {
+    struct ent *p2;
+    char *s = NULL;
+
+    if(rw != TRG_WRITE) return(1);
+
+    if((p2 = lookat(p->row, p->col+1))) {
+        // if the cell has a label, write its reverse to the target cell
+        if (p->flags & is_label){
+            if (p->label && !(s=strrev(p->label))) return(2);
+            label(p2,s,0);
+            if(s) scxfree(s);
+        }
+        // if the cell has a value, write its negative to the target cell
+        p2->flags &= ~is_valid;
+        p2->flags |= is_changed | iscleared;
+        if (p->flags & is_valid){
+            p2->v=-p->v;
+            p2->flags |= is_changed | is_valid;
+            p2->flags &= ~iscleared;
+            p2->cellerror = CELLOK;
+        }
+    }
+
+    return(0);
+}
+

--- a/src/cmds_visual.c
+++ b/src/cmds_visual.c
@@ -223,8 +223,11 @@ void do_visualmode(struct block * buf) {
                 while (row_hidden[-- r->brrow]);
                 currow = r->brrow;
             } else if (r->tlrow <= r->brrow && r->tlrow-1 >= 0) {
-                while (row_hidden[-- r->tlrow]);
-                currow = r->tlrow;
+                int newrow = r->tlrow;
+                while (newrow > 0 && row_hidden[-- newrow]);
+                if (!row_hidden[newrow]) {
+                    currow = r->tlrow = newrow;
+                }
             }
 
     // DOWN - ctl('f')

--- a/src/cmds_visual.c
+++ b/src/cmds_visual.c
@@ -239,8 +239,8 @@ void do_visualmode(struct block * buf) {
         } else n = 1;
 
         for (i=0; i < n; i++)
-            if (r->orig_row <= r->tlrow && r->tlrow <= r->brrow && r->brrow+1 < maxrows) {
-                while (row_hidden[++ r->brrow]);
+            if (r->orig_row <= r->tlrow && r->tlrow <= r->brrow) {
+                while (r->brrow+1 < maxrows && row_hidden[++ r->brrow]);
                 currow = r->brrow;
             } else if (r->tlrow <  r->brrow) {
                 while (row_hidden[++ r->tlrow]);

--- a/src/doc
+++ b/src/doc
@@ -1340,8 +1340,9 @@ Commands for handling cell content:
                                returns value
      sc.lsetnum (c, r, val)  - set numeric value to a cell c,t
      sc.lsetform (c, r, str) - set formula to a cell. Basically it does "let cell= str"
-     sc.setstr(c, r, str)    - set string to a cell
-     sc.query(str)           - query input from user, but first prints str. Use with care!!
+     sc.lsetstr(c, r, str)   - set string to a cell
+     sc.lgetstr(c, r, str)   - get string from a cell
+     sc.lquery(str)          - query input from user, but first prints str. Use with care!!
                                Dont use this function within triggers!!
                                returns string
      sc.sc(str)              - send str to sc-im parser

--- a/src/gram.y
+++ b/src/gram.y
@@ -429,6 +429,10 @@ command:
                                   $2.left.vp->flags |= is_changed;
                                   modflg++;
 
+                                  // clearing the value counts as a write, so run write triggers
+                                  if (( $2.left.vp->trigger  ) && (($2.left.vp->trigger->flag & TRG_WRITE) == TRG_WRITE))
+                                      do_trigger($2.left.vp,TRG_WRITE);
+
                                   #ifdef UNDO
                                   copy_to_undostruct($2.left.vp->row, $2.left.vp->col, $2.left.vp->row, $2.left.vp->col, 'a');
                                   // here we save in undostruct, all the ents that depends on the deleted one (after change)

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -232,9 +232,12 @@ void do_trigger( struct ent *p , int rw) {
  */
 
 void do_C_Trigger_cell(struct ent * p, int rw) {
+    int status;
     int (*function)(struct ent *, int );
 
     function = p->trigger->c_function;
-    printf ("%d\n", (*function)(p,rw ));
+    if ( (status = (*function)(p,rw ))) {
+        sc_info("Trigger reported error code: %d", status);
+    }
     return;
 }

--- a/src/vmtbl.c
+++ b/src/vmtbl.c
@@ -160,10 +160,20 @@ int growtbl(int rowcol, int toprow, int topcol) {
 #ifndef PSC
     /* set how much to grow */
     if ((rowcol == GROWROW) || (rowcol == GROWBOTH)) {
+        if ((maxcols == MAXROWS) || (toprow >= MAXROWS)) {
+            sc_error(nolonger);
+            return (FALSE);
+        }
+
         if (toprow > maxrows)
             newrows = GROWAMT + toprow;
         else
             newrows += GROWAMT;
+
+        /* If we're close but less than MAXROWS, clip to max value */
+        if ( newrows > MAXROWS )
+            newrows = MAXROWS;
+
     }
 #endif /* !PSC */
     if ((rowcol == GROWCOL) || (rowcol == GROWBOTH)) {
@@ -179,11 +189,6 @@ int growtbl(int rowcol, int toprow, int topcol) {
 
         if (newcols > ABSMAXCOLS)
             newcols = ABSMAXCOLS;
-    }
-
-    if (newrows > MAXROWS) { // 08/12/2014
-        sc_error(nolonger);
-        return (FALSE);
     }
 
 #ifndef PSC

--- a/src/vmtbl.c
+++ b/src/vmtbl.c
@@ -173,11 +173,10 @@ int growtbl(int rowcol, int toprow, int topcol) {
         /* If we're close but less than MAXROWS, clip to max value */
         if ( newrows > MAXROWS )
             newrows = MAXROWS;
-
     }
 #endif /* !PSC */
     if ((rowcol == GROWCOL) || (rowcol == GROWBOTH)) {
-        if ((rowcol == GROWCOL) && ((maxcols == ABSMAXCOLS) || (topcol >= ABSMAXCOLS))) {
+        if ((maxcols == ABSMAXCOLS) || (topcol >= ABSMAXCOLS)) {
             sc_error(nowider);
             return (FALSE);
         }


### PR DESCRIPTION
- lua functions are missing or misnamed in doc
- `do_C_Trigger_cell` calls `printf()` to report return value of trigger, which interferes with ncurses. Call `sc_info` instead and only for non-zero return values.
- clearing a value does not invoke write trigger
- add another c module example which shows how to call back into sc-im API in order to manipulate sheet
- Table cannot grow up to MAXROWS exactly
- bug in visual mark logic when selecting up and first line is hidden #277