### PR TITLE
Add command "wq" and "wq {file}" to mimic Vim

### DIFF
--- a/src/cmds_command.c
+++ b/src/cmds_command.c
@@ -853,7 +853,7 @@ void do_commandmode(struct block * sb) {
             exec_cmd(line);
 
         } else if ( inputline[0] == L'w' ) {
-            if (savefile() == 0 && ! wcscmp(inputline, L"wq")) shall_quit = 1;
+            if (savefile() == 0 && ! wcsncmp(inputline, L"wq", 2)) shall_quit = 1;
 
         } else if ( ! wcsncmp(inputline, L"file ", 5) ) {
 

--- a/src/doc
+++ b/src/doc
@@ -330,6 +330,8 @@ Commands for handling cell content:
      :w {file}   Save the current spreadsheet as {file}.
      :w! {file}  Save the current spreadsheet as {file}, forcing an overwrite
                  if {file} already exists.
+     :wq         Save the current spreadsheet and quit SC-IM.
+     :wq {file}  Save the current spreadsheet as {file} and quit SC-IM.
 
      :h          Show this help.
      :help       Show this help.

--- a/src/file.c
+++ b/src/file.c
@@ -189,21 +189,23 @@ int modcheck() {
 
 int savefile() {
     int force_rewrite = 0;
+    int shall_quit = 0;
     char name[BUFFERSIZE];
     #ifndef NO_WORDEXP
     size_t len;
     wordexp_t p;
     #endif
 
-    if (! curfile[0] && wcslen(inputline) < 3) { // casos ":w" ":w!" ":x" ":x!"
+    if (! curfile[0] && wcslen(inputline) < 3) { // casos ":w" ":w!" ":wq" ":x" ":x!"
         sc_error("There is no filename");
         return -1;
     }
 
     if (inputline[1] == L'!') force_rewrite = 1;
+    if (inputline[1] == L'q') shall_quit = 1;
 
     wcstombs(name, inputline, BUFFERSIZE);
-    del_range_chars(name, 0, 1 + force_rewrite);
+    del_range_chars(name, 0, 1 + force_rewrite + shall_quit);
 
     #ifndef NO_WORDEXP
     wordexp(name, &p, 0);
@@ -221,7 +223,7 @@ int savefile() {
     #endif
 
     if (! force_rewrite && file_exists(name)) {
-        sc_error("File already exists. Use \"!\" to force rewrite.");
+        sc_error("File already exists. Use \"w!\" to force rewrite.");
         return -1;
     }
 
@@ -235,7 +237,7 @@ int savefile() {
     // if it exists and no '!' is set, return.
     if (!strlen(curfile) && backup_exists(name)) {
         if (!force_rewrite) {
-            sc_error("Backup file of %s exists. Use \"!\" to force the write process.", name);
+            sc_error("Backup file of %s exists. Use \"w!\" to force the write process.", name);
             return -1;
         } else remove_backup(name);
     }


### PR DESCRIPTION
As the error `File already exists. Use \"!\" to force rewrite.` now does not only occur with the command w but may also occur with the command wq, it has been changed into `File already exists. Use \"w!\" to force rewrite.` to avoid any ambiguity.