### PR TITLE
zlib also required to compile with libxlsxwriter

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -75,11 +75,11 @@ endif
 # NOTE: libxlsxwriter is required for xlsx file export support
 ifneq (,$(wildcard /usr/include/xlsxwriter.h))
   CFLAGS += -DXLSX_EXPORT
-  LDLIBS += -lxlsxwriter
+  LDLIBS += -lxlsxwriter -lz
 endif
 ifneq (,$(wildcard /usr/local/include/xlsxwriter.h))
   CFLAGS += -DXLSX_EXPORT
-  LDLIBS += -lxlsxwriter
+  LDLIBS += -lxlsxwriter -lz
 endif
 
 # Check for gnuplot existance


### PR DESCRIPTION
I've encountered a compilation problem when not using `-lz` to compile with `libxlsxwriter` support. You should consider including it in `Makefile`.