### PR TITLE
Install data files with permissions 644

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -162,8 +162,8 @@ install :
 	install -d $(DESTDIR)$(prefix)/bin
 	install $(name) $(DESTDIR)$(prefix)/bin/$(name)
 	install -d $(DESTDIR)$(HELPDIR)
-	install doc $(DESTDIR)$(HELPDIR)/$(name)_help
-	install plot_* $(DESTDIR)$(HELPDIR)/
+	install -m 644 doc $(DESTDIR)$(HELPDIR)/$(name)_help
+	install -m 644 plot_* $(DESTDIR)$(HELPDIR)/
 	install -d $(DESTDIR)$(MANDIR)/
 	install -m 644 sc-im.1 $(DESTDIR)$(MANDIR)/$(name).1
 


### PR DESCRIPTION
Prevents 'install' from adding a +x bit.

This is a patch from the pkgsrc work (#303).