### PR TITLE
Fix segfault when fcopy'ing with no selection while on first column

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -2169,6 +2169,12 @@ int fcopy() {
     }
 
     if (p == -1) { // no range selected
+        // fail if the cursor is on the first column
+        if (curcol == 0) {
+            sc_error("Can't fcopy with no arguments while on column 'A'");
+            return -1;
+        }
+
         ri = currow;
         ci = curcol;
         cf = curcol;


### PR DESCRIPTION
Happened to me before I read  up how fcopy actually worked, and while not many people will come across this case I still think it'd be nice to display a proper error. 3rd PR from a 16 year old, so please be gentle with your feedback :)