### PR TITLE
Enable trigger saving, cleanup trailing whitespace, fix comment typo,…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{c,h}]
+charset = utf-8
+
+[*.{c,h}]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+

--- a/src/file.c
+++ b/src/file.c
@@ -606,9 +606,9 @@ void write_cells(register FILE *f, int r0, int c0, int rn, int cn, int dr, int d
                     (void) fprintf(f, "%s\n",line);
                 }
                 if ((*pp)->trigger != NULL) {
+                    struct trigger* t;
                     char* mode;
                     char* type;
-                    struct trigger* t;
                     t = (*pp)->trigger;
                     if ((t->flag & (TRG_READ | TRG_WRITE)) == (TRG_READ | TRG_WRITE)) mode = "RW";
                     if ((t->flag & TRG_WRITE) == TRG_WRITE) mode = "W";


### PR DESCRIPTION
… and add .editorconfig to make contributing slightly easier.

I made [an issue](https://github.com/andmarti1424/sc-im/issues/319) about a half-hour ago to allow triggers to be saved with the `.sc` file. Turns out, this codebase is easier to contribute to than I anticipated! Kudos!

Resolves #319 