### PR TITLE
command line option to export

### DIFF
--- a/src/doc
+++ b/src/doc
@@ -1450,4 +1450,9 @@ Commands for handling cell content:
 
     Note: Setting the --output parameter implies setting the --nocurses flag.
 
+    Export to csv, tab or plain text formats without interaction:
+        ./sc-im --quit_afterload --nocurses --export_csv
+        ./sc-im --quit_afterload --nocurses --export_tab
+        ./sc-im --quit_afterload --nocurses --export_txt   # (or just --export)
+        
  vim:tw=78:ts=8:ft=help:norl:

--- a/src/file.c
+++ b/src/file.c
@@ -1155,12 +1155,16 @@ void export_plain(char * fname, int r0, int c0, int rn, int cn) {
     int pid;
     wchar_t out[FBUFLEN] = L"";
 
-    sc_info("Writing file \"%s\"...", fname);
-
-    if ((f = openfile(fname, &pid, NULL)) == (FILE *)0) {
-        sc_error ("Can't create file \"%s\"", fname);
-        return;
+    if (fname == NULL)
+        f = stdout;
+    else {
+        sc_info("Writing file \"%s\"...", fname);
+        if ((f = openfile(fname, &pid, NULL)) == (FILE *)0) {
+            sc_error ("Can't create file \"%s\"", fname);
+            return;
+        }
     }
+
     struct ent * ent = go_end();
     if (rn > ent->row) rn = ent->row;
 
@@ -1221,10 +1225,11 @@ void export_plain(char * fname, int r0, int c0, int rn, int cn) {
         }
         (void) fprintf(f,"\n");
     }
-    closefile(f, pid, 0);
-
-    if (! pid) {
-        sc_info("File \"%s\" written", fname);
+    if (fname != NULL) {
+        closefile(f, pid, 0);
+        if (! pid) {
+            sc_info("File \"%s\" written", fname);
+        }
     }
 
 }
@@ -1253,9 +1258,13 @@ void export_delim(char * fname, char coldelim, int r0, int c0, int rn, int cn, i
 
     if (verbose) sc_info("Writing file \"%s\"...", fname);
 
-    if ((f = openfile(fname, &pid, NULL)) == (FILE *)0) {
-        if (verbose) sc_error ("Can't create file \"%s\"", fname);
-        return;
+    if (fname == NULL)
+        f = stdout;
+    else {
+        if ((f = openfile(fname, &pid, NULL)) == (FILE *)0) {
+            if (verbose) sc_error ("Can't create file \"%s\"", fname);
+            return;
+        }
     }
 
     struct ent * ent = go_end();
@@ -1295,7 +1304,8 @@ void export_delim(char * fname, char coldelim, int r0, int c0, int rn, int cn, i
         }
         (void) fprintf(f,"\n");
     }
-    closefile(f, pid, 0);
+    if (fname != NULL)
+        closefile(f, pid, 0);
 
     if (! pid && verbose) {
         sc_info("File \"%s\" written", fname);

--- a/src/main.c
+++ b/src/main.c
@@ -321,6 +321,18 @@ int main (int argc, char ** argv) {
     lastbackup_tv = (struct timeval) {0};
     #endif
 
+    if (get_conf_value("export_csv")) {
+        export_delim(NULL, ',', 0, 0, maxrow, maxcol, 0);
+    }
+
+    if (get_conf_value("export_tab")) {
+        export_delim(NULL, '\t', 0, 0, maxrow, maxcol, 0);
+    }
+
+    if (get_conf_value("export") || get_conf_value("export_txt")) {
+        export_plain(NULL, 0, 0, maxrow, maxcol);
+    }
+
     while ( ! shall_quit && ! atoi((char *) get_conf_value("quit_afterload"))) {
         // save current time for runtime timer
         gettimeofday(&current_tv, NULL);


### PR DESCRIPTION
## Synopsis
Adds command line options: `--export_csv`, `--export_tab`, `--export_txt` and `--export`, synonymous with `--export_txt`.
## Need
There needs to be a way to convert `.sc` files to text form, without having to manually enter the command in the UI or to fake the _curses_ environment. Also separately requested in #359.
Notably, with this fix, one can add the following to `.gitattributes`
```
*.sc diff=scim
```
and
```
[diff "scim"]
   textconv = sc-im --quit_afterload --nocurses --export
   cachetextconv = false
```
in `.gitconfig` and get visual diffs of the spreadsheets.
