### PR TITLE
Include string.h where needed

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -43,6 +43,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include <ctype.h>   // for isdigit
 #include <wchar.h>
 #include <wctype.h>

--- a/src/cmds_normal.c
+++ b/src/cmds_normal.c
@@ -44,6 +44,7 @@
 
 #include <ctype.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "yank.h"
 #include "marks.h"

--- a/src/dep_graph.c
+++ b/src/dep_graph.c
@@ -59,6 +59,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <setjmp.h>
 #include <math.h>
 

--- a/src/file.c
+++ b/src/file.c
@@ -50,6 +50,7 @@
 #include <signal.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <wchar.h>
 #include <sys/wait.h>

--- a/src/gram.y
+++ b/src/gram.y
@@ -1,5 +1,6 @@
 %{
 #include <stdlib.h>
+#include <string.h>
 
 #include "sc.h"
 #include "cmds.h"

--- a/src/hide_show.c
+++ b/src/hide_show.c
@@ -43,6 +43,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "sc.h"
 #include "macros.h"

--- a/src/subtotal.c
+++ b/src/subtotal.c
@@ -42,6 +42,7 @@
  * \brief TODO Write a tbrief file description.
  */
 
+#include <string.h>
 #include <wchar.h>
 #include "sc.h"
 #include "macros.h"
@@ -51,7 +52,6 @@
 
 /*
 #include <sys/types.h>
-#include <string.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>


### PR DESCRIPTION
Should be included for functions like strcmp. It should not be assumed
that it is included through other headers, e.g. on SmartOS it [isn't](1).

[1]: https://us-east.manta.joyent.com/pkgsrc/public/reports/upstream-trunk/20191223.2256/sc-im-0.7.0nb6/build.log