### PR TITLE
add EXECUTE command for making non-interactive scripts more powerfull

### DIFF
--- a/examples/nocurses/export_to_mkd.sc
+++ b/examples/nocurses/export_to_mkd.sc
@@ -1,0 +1,7 @@
+label A0 = "Col1"
+label B0 = "Col2"
+let A1=0
+let B1=2
+execute "e! mkd /tmp/test.md"
+quit
+

--- a/examples/nocurses/nocurses.readme
+++ b/examples/nocurses/nocurses.readme
@@ -1,0 +1,18 @@
+These are examples how to run sc-im with the -nocurses option
+
+COMMAND:
+cat examples/nocurses/export_to_mkd.sc | sc-im --nocurses examples/sc/subtotals.sc && cat /tmp/test.md
+
+STDOUT:
+Writing file "/tmp/test.md"...
+File "/tmp/test.md" written
+quitting. unsaved changes will be lost.
+|    Col1    |    Col2    |
+|:----------:|:----------:|
+|       0.00 |       2.00 |
+
+COMMAND:
+echo "let A0=1\nlet A1=1\nlet A2=A0+A1\nrecalc\nexecute \"version\"\n\n"| ./src/sc-im --nocurses --quit_afterload
+
+STDOUT:
+Prints version end waits for quit.

--- a/src/main.c
+++ b/src/main.c
@@ -334,7 +334,7 @@ int main (int argc, char ** argv) {
 
         // if we are not in ncurses
         } else if (fgetws(nocurses_buffer, BUFFERSIZE, f) != NULL) {
-            sc_info("Interp will receive: %ls", nocurses_buffer);
+            sc_debug("Interp will receive: %ls", nocurses_buffer);
             send_to_interp(nocurses_buffer);
         }
 
@@ -397,7 +397,7 @@ void read_stdin() {
     if (select(1, &readfds, NULL, NULL, &timeout)) {
         //sc_debug("there is data");
         while (f != NULL && fgetws(stdin_buffer, BUFFERSIZE, f) != NULL) {
-            sc_info("Interp will receive: %ls", stdin_buffer);
+            sc_debug("Interp will receive: %ls", stdin_buffer);
             send_to_interp(stdin_buffer);
         }
         fflush(f);


### PR DESCRIPTION
I hope you like this patch. It add's the EXECUTE command to give non interactive scripts access to all command mode commands, e.g. for exporting. E.g.

```
label A0 = "Col1"
label B0 = "Col2"
let A1=0
let B1=2
execute "e! txt /tmp/test.txt"
quit
```