### PR TITLE
Add execute command and documentation update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ src/experres.h
 src/gram.c
 src/sc-im
 src/statres.h
+doc/grammar_yacc_tools/commands.txt
+doc/grammar_yacc_tools/setitems.txt
+doc/grammar_yacc_tools/term_list.txt
+doc/grammar_yacc_tools/yacc-format-stage1

--- a/doc/grammar_yacc_tools/Makefile
+++ b/doc/grammar_yacc_tools/Makefile
@@ -1,0 +1,37 @@
+all: parse_yacc command_list setitem_list term_list
+
+parse_yacc:
+	./y2l ../../src/gram.y | pandoc -f latex -t markdown | \
+		sed 's/^[[:space:]][[:space:]]//g' |\
+		sed 's/[S\_|K\_]\\_//g' | \
+		sed 's/\\_/_/g' | \
+		sed 's/[\*\*|\$$|"]//g' |\
+		sed 's/[[:space:]]e[[:space:]]/\{expr\}/g' | \
+		sed 's/[[:space:]]e$$/\{expr\}/g'|\
+		sed 's/@[[:space:]]/@/g'|\
+		sed 's/::=[[:space:]]+//g'|\
+		sed 's/::=[[:space:]]!//g'|\
+		sed 's/[[:space:]]var_or_range/\ {var_or_range}/g' |\
+		sed 's/[[:space:]]var/\ {var}/g' |\
+		sed 's/[[:space:]]expr_list/\ {expr_list}/g' |\
+		sed 's/[[:space:]]range/\ {range}/g' |\
+		sed 's/[[:space:]]COL/\ {COL}/g' |\
+		sed 's/[[:space:]]NUMBER/\ {NUMBER}/g' |\
+		sed 's/[[:space:]]STRING/\ {STRING}/g' |\
+		sed 's/[[:space:]]strarg/\ {strarg}/g' |\
+		sed 's/[[:space:]]WORD/\ {WORD}/g' |\
+		sed 's/[[:space:]]setitem/\ {setitem}/g' |\
+		sed 's/[[:space:]]setlist/\ {setlist}/g' |\
+		sed 's/[[:space:]]num/\ {num}/g' |\
+		sed 's/{COL}OR/COLOR/g' |\
+		sed 's/[[:space:]]$$//g'|\
+		sed 's/xxxxx/yyyyy/g' > yacc-format-stage1
+
+command_list:
+	grep -i "^command" ./yacc-format-stage1 | cut -d"=" -f2| sed 's/^[[:space:]]//g' > commands.txt
+
+setitem_list:
+	grep -i "^setitem" ./yacc-format-stage1 | cut -d"=" -f2,3| sed 's/^[[:space:]]//g' > setitems.txt
+
+term_list:
+	grep -i "^term" ./yacc-format-stage1 | cut -d"=" -f2| sed 's/^[[:space:]]//g' > term_list.txt

--- a/doc/grammar_yacc_tools/README.md
+++ b/doc/grammar_yacc_tools/README.md
@@ -1,0 +1,3 @@
+# Grammar YACC Tools
+
+Use this Makefile targets to generate lists with internal YACC-commands from ./src/gram.y

--- a/doc/grammar_yacc_tools/y2l
+++ b/doc/grammar_yacc_tools/y2l
@@ -1,0 +1,1150 @@
+#!/usr/bin/awk -f
+
+###############################################################################
+#
+#  FILE:	y2l
+#  DESCRIPTION: Yacc-to-LaTeX grammar processor
+#
+#  Copyright (c) 1994-2000 by Kris Van Hees, Belgium.  All rights reserved.
+#  See the "Artistic License" included in this package (file: "Artistic") for
+#  terms and conditions.
+#
+#  $Id: y2l,v 1.1.1.1 2000/03/07 16:40:33 aedil Exp $
+#
+###############################################################################
+
+#
+# Reserved variables:
+#	_debug		Debug level
+#	_exit		Exiting due to an error
+#	_line		Current line being processed
+#	_spclen		Length of string holding padding spaces
+#	_spcstr		String to hold padding spaces
+#
+
+###############################################################################
+# Support functions
+###############################################################################
+
+#
+#  NAME:	SPACES()
+#  DESCRIPTION: return a given number of spaces
+#
+function SPACES(snum) {
+    if (!_spclen) {				# uninitialized (first use)
+	_spcstr = " ";
+	_spclen = 1;
+    }
+
+    while (_spclen < snum) {			# extend the string of spaces
+	_spcstr = _spcstr _spcstr;		# double the spaces
+	_spclen *= 2;				# update the string length
+    }
+
+     return substr(_spcstr, 1, snum);		# requested number of spaces
+}
+
+#
+#  NAME:	DBG()
+#  DESCRIPTION: write debug output to standard error (if debugging is enabled)
+#
+function DBG(dlvl, dmsg) {
+    if (!_debug)				# debugging is disabled
+	return;
+
+    print "DBG:" SPACES(dlvl * 2 + 1) dmsg			>"/dev/stderr";
+}
+
+#
+#  NAME:	error()
+#  DESCRIPTION: write an error message to standard error
+#
+function error(emsg) {
+    print "ERROR: " emsg					>"/dev/stderr";
+
+    if (_line)
+	print "       Line is (on or about) " _line		>"/dev/stderr";
+
+    _exit = 1;					# mark program as exiting
+    exit;
+}
+
+#
+#  NAME:	exiting()
+#  DESCRIPTION: return whether the program is exiting
+#
+function exiting() {
+    return _exit;				# exit status
+}
+
+#
+#  NAME:	exists()
+#  DESCRIPTION: return whether a file exists
+#
+function exists(fname) {
+    return !system("ls " fname " >/dev/null 2>&1");
+}
+
+###############################################################################
+# Yacc-to-LaTeX initialization
+###############################################################################
+
+#
+#  NAME:	init()
+#  DESCRIPTION: initialization
+#
+function init() {
+    PERC_PERC			= 257;
+    PERC_LACC			= 258;
+    PERC_RACC			= 259;
+    PERC_LEFT			= 260;
+    PERC_ASSC			= 261;
+    PERC_RGHT			= 262;
+    PERC_STRT			= 263;
+    PERC_TOKN			= 264;
+    PERC_TYPE			= 265;
+    PERC_UNIO			= 266;
+    PERC_PREC			= 267;
+
+    CHAR			= 268;
+    IDENT			= 269;
+    STRING			= 270;
+    TYPE			= 271;
+
+    EOF				= -1;
+    BAD				= -2;
+
+    reserved["%%"]		= PERC_PERC;
+    reserved["%{"]		= PERC_LACC;
+    reserved["%}"]		= PERC_RACC;
+    reserved["%left"]		= PERC_LEFT;
+    reserved["%nonassoc"]	= PERC_ASSC;
+    reserved["%right"]		= PERC_RGHT;
+    reserved["%start"]		= PERC_STRT;
+    reserved["%token"]		= PERC_TOKN;
+    reserved["%type"]		= PERC_TYPE;
+    reserved["%union"]		= PERC_UNIO;
+    reserved["%prec"]		= PERC_PREC;
+}
+
+###############################################################################
+# Yacc-to-LaTeX processor functions
+###############################################################################
+
+#
+#  NAME:	token()
+#  DESCRIPTION: verify whether something is a valid token
+#
+function token(tokname) {
+    return tokname ~ /^[_\.A-Za-z][_\.A-Za-z0-9]*$/;
+}
+
+#
+#  NAME:	read()
+#  DESCRIPTION: read another (non-blank) line from the input file
+#
+function read() {
+    while (getline < grammar_file == 1) {
+	_line++;
+
+	if ($1 != "")
+	    return;
+    }
+
+    return grammar_eof = 1;
+}
+
+#
+#  NAME:	skip_ws()
+#  DESCRIPTION: skip a continuous block of whitespace
+#
+function skip_ws() {
+    in_comment = 0;
+
+    while (!grammar_eof) {
+	sub(/^[ \t]+/, "");			# remove leading whitespace
+
+	if ($1 != "") {
+	    if (/^\/\//) {			# C++ comment
+		$0 = "";
+	    } else if (in_comment) {		# in a comment
+		if (match($0, /\*\//)) {	# end of a comment
+		    $0 = substr($0, RSTART + RLENGTH);
+		    in_comment = 0;
+		} else
+		    $0 = "";
+	    } else if (/^\/\*"[^"]+"\*\//) {	# special marker
+		sub(/\/\*"/, "\"");
+		sub(/"\*\//, "\"");
+
+		return;
+	    } else if (/^\/\*/) {		# regular comment
+		$0 = substr($0, 3);
+		in_comment = 1;
+	    } else
+		return;
+
+	    sub(/[ \t]+$/, "");			# remove trailing whitespace
+	}
+
+	if ($1 == "")
+	    read();
+    }
+}
+
+#
+#  NAME:	lex()
+#  DESCRIPTION: read the next token from the input
+#
+function lex() {
+    if (tok_prev) {
+	tok = tok_prev;
+	tok_str = tok_pstr;
+	tok_prev = 0;
+
+	return tok;
+    }
+
+    skip_ws();
+
+    if (grammar_eof)
+	return EOF;
+
+    if (/^%/)
+	if (match($0, /^%(%|{|}|left|nonassoc|right|start|token|type|union)/)) {
+	    tok_str = substr($0, 1, RLENGTH);
+	    $0 = substr($0, RLENGTH + 1);
+
+	    return reserved[tok_str];
+	} else if (match($0, /^%[_A-Za-z][_A-Za-z0-9]*/)) {
+	    tok_str = substr($0, 1, RLENGTH);
+	    $0 = substr($0, RLENGTH + 1);
+
+	    return BAD;
+	}
+
+    if (match($0, /^[_\.A-Za-z][_\.A-zA-z0-9]*/)) {
+	tok_str = substr($0, 1, RLENGTH);
+	$0 = substr($0, RLENGTH + 1);
+
+	return IDENT;
+    }
+
+    if (match($0, /^<[_\.A-Za-z][_\.A-zA-z0-9]*>/)) {
+	tok_str = substr($0, 1, RLENGTH);
+	$0 = substr($0, RLENGTH + 1);
+
+	return TYPE;
+    }
+
+    if (/^'/)
+	if (match($0, /^'(.|\\([tnarfbv\\'"]|[0-7][0-7]*))'/)) {
+	    tok_str = "@C" (consts++);
+	    transtab[tok_str] = "\"" substr($0, 2, RLENGTH - 2) "\"";
+	    $0 = substr($0, RLENGTH + 1);
+
+	    return CHAR;
+	} else
+	    error("Excuse me, but this character constant is a bit weird.");
+
+    if (/^"/)
+	if (match($0, /([^\\]|[ \t]+)(\\\\)*"/)) {
+	    tok_str = "@S" (strings++);
+	    transtab[tok_str] = substr($0, 1, RSTART + RLENGTH - 1);
+	    $0 = substr($0, RSTART + RLENGTH);
+
+	    return STRING;
+	} else
+	    error("Newlines in strings are interesting, but not allowed.");
+
+    tok_str = substr($0, 1, 1);
+    $0 = substr($0, 2);
+
+    return tok_str;
+}
+
+#
+#  NAME:	unlex()
+#  DESCRIPTION: return a token to the input stream
+#
+function unlex(tok) {
+    tok_prev = tok;
+    tok_pstr = tok_str;
+}
+
+#
+#  NAME:	skip_definition()
+#  DESCRIPTION: skip the contents of a %{ ... %} block
+#
+function skip_definition() {
+    do {
+	skip = lex();
+    } while (skip != PERC_RACC && skip != EOF);
+}
+
+#
+#  NAME:	decl_token()
+#  DESCRIPTION: read a token declaration
+#
+function decl_token() {
+    first = 1;
+
+    do {
+	tok = lex();
+
+	if (tok == ",") {
+	    symbol = 0;
+	} else if (tok == CHAR) {
+	    DBG(1, transtab[tok_str] ": No need to remember this token.");
+	} else if (tok == IDENT) {
+	    if (_tkpat && tok_str !~ _tkpat) {
+		if (transtab[tok_str])
+		    DBG(2, "WARNING: Redefining '" tok_str "'.");
+
+		transtab[tok_str] = "\"" tolower(tok_str) "\"";
+		DBG(1, tok_str ": Defined as " transtab[tok_str] ".");
+	    }
+
+	    symbol = tok_str;
+	} else if (tok == NUMBER) {
+	    if (!symbol)
+		error("How about giving a token first?");
+
+	    symbol = 0;
+	} else if (tok == STRING) {
+	    if (!symbol)
+		error("How about giving a token first?");
+
+	    str = transtab[tok_str];
+	    transtab[symbol] = "\"" substr(str, 2, length(str) - 2) "\"";
+	    DBG(1, SPACES(length(symbol) + 2)				      \
+		   "Defined as " transtab[symbol] ".");
+
+	    symbol = 0;
+	} else if (tok == TYPE) {
+	    if (!first)
+		error("This is no place for a type name.");
+	} else {
+	    unlex(tok);
+	    return;
+	}
+
+	first = 0;
+    } while (tok != EOF);
+}
+
+#
+#  NAME:	decl_start()
+#  DESCRIPTION: read a start rule declaration
+#
+function decl_start() {
+    if (grammar_start)
+	error("Hm, you want the grammar to start with two rules?");
+    else if (lex() == IDENT) {
+	grammar_start = tok_str;
+	DBG(2, "The grammar start rule is '" grammar_start "'.");
+    } else
+	error("How about a nice juicy identifier?");
+}
+
+#
+#  NAME:	decl_type()
+#  DESCRIPTION: read a type declaration
+#
+function decl_type() {
+    if (lex() != TYPE)
+	error("So where is the typename?");
+
+    do {
+	tok = lex();
+
+	if (tok == ",") {
+	    symbol = 0;
+	} else if (tok == CHAR) {
+	    error("Bison etc may accept literals in a %type declaration, "    \
+		  "but the Unix 7th\n       Ed manual clearly indicates "     \
+		  "that it is NOT legal.  And I think that the\n       Bell " \
+		  "Labs guys know what they are talking about; but anyway, "  \
+		  "do you\n       really spend the time reading this long "   \
+		  "error message?");
+	} else if (tok == IDENT) {
+	    if (_tkpat && tok_str !~ _tkpat) {
+		if (transtab[tok_str])
+		    DBG(2, "WARNING: Redefining '" tok_str "'.");
+
+		transtab[tok_str] = "\"" tolower(tok_str) "\"";
+		DBG(1, tok_str ": Defined as " transtab[tok_str] ".");
+	    }
+
+	    symbol = tok_str;
+	} else if (tok == NUMBER) {
+	    if (!symbol)
+		error("How about giving a token first?");
+
+	    symbol = 0;
+	} else if (tok == STRING) {
+	    if (!symbol)
+		error("How about giving a token first?");
+
+	    str = transtab[tok_str];
+	    transtab[symbol] = "\"" substr(str, 2, length(str) - 2) "\"";
+	    DBG(1, SPACES(length(symbol) + 2)				      \
+		   "Defined as " transtab[symbol] ".");
+
+	    symbol = 0;
+	} else {
+	    unlex(tok);
+	    return;
+	}
+    } while (tok != EOF);
+}
+
+#
+#  NAME:	decl_union()
+#  DESCRIPTION: read a union declaration
+#
+function decl_union() {
+    if (grammar_union)
+	error("How about sticking to one single union declaration?");
+
+    grammar_union = 1;
+    DBG(2, "Extended types have been registered with a union declaration.");
+
+    do {
+	tok = lex();
+
+	if (tok == "{")
+	    block++;
+	else if (tok == "}") {
+	    if (!block)
+		error("Why close an unopened block?");
+	    if (--block <= 0)
+		return;
+	} else if (tok == EOF)
+	    error("The file ends before the union is finished.  How rude!");
+    } while (1);
+}
+
+#
+#  NAME:	read_declarations()
+#  DESCRIPTION: read the yacc declarations
+#
+function read_declarations() {
+    do {
+	tok = lex();				# next token
+
+	if (tok == PERC_PERC || tok == EOF)	# end of the declarations
+	    return;
+	if (tok == PERC_LACC) {			# definition block
+	    skip_definition();
+	} else if (tok == PERC_LEFT) {		# left associative declaration
+	    decl_token();
+	} else if (tok == PERC_ASSC) {		# non-associative declaration
+	    decl_token();
+	} else if (tok == PERC_RGHT) {		# right associative declaration
+	    decl_token();
+	} else if (tok == PERC_STRT) {		# start rule declaration
+	    decl_start();
+	} else if (tok == PERC_TOKN) {		# token declaration(s)
+	    decl_token();
+	} else if (tok == PERC_TYPE) {		# type declaration
+	    decl_type();
+	} else if (tok == PERC_UNIO) {		# union declaration
+	    decl_union();
+	} else
+	    DBG(2, "WARNING: Ignoring the unknown token '" tok_str "'.");
+    } while (1);
+}
+
+#
+#  NAME:	skip_action()
+#  DESCRIPTION: skip the contents of an action block
+#
+function skip_action() {
+    block = 1;
+
+    do {
+	tok = lex();
+
+	if (tok == "{")
+	    block++;
+	else if (tok == "}") {
+	    if (!block)
+		error("Why close an unopened block?");
+	    if (--block <= 0)
+		return;
+	} else if (tok == EOF)
+	    error("The file ends before the action is finished.  How rude!");
+    } while (tok != EOF);
+}
+
+#
+#  NAME:	read_grammar()
+#  DESCRIPTION: read the yacc grammar
+#
+function read_grammar() {
+    tok = lex();
+
+    do {
+	if (tok == PERC_PERC || tok == EOF)	# end of the grammar
+	    return;
+
+	if (tok == IDENT) {			# rule begins here
+	    if (!(rule_idx = rule_ref[tok_str])) {
+		rule_idx = ++rule_cnt;		# new rule
+		rule_lhs[rule_idx] = tok_str;
+		rule_ref[tok_str] = rule_idx;
+		rule_sub = ++rule_len[rule_idx];
+
+		if (!grammar_start)
+		    grammar_start = tok_str;
+	    }
+
+	    if (lex() != ":")
+		error("The LHS and RHS would like to be separated by a colon.");
+	} else if (tok == "|") {		# alternative RHS for a rule
+	    if (!rule_cnt)
+		error("The grammar shouldn't start with a |.");
+
+	    rule_sub = ++rule_len[rule_idx];
+	} else
+	    error("You could at least give a valid token.");
+
+	rule_rhs[rule_cnt] = "";		# empty RHS
+
+	do {					# read the RHS
+	    tok = lex();
+
+	    if (tok == PERC_PREC) {		# %prec
+		tok = lex();
+
+		if (tok != IDENT && tok != CHAR)
+		    error("What precedence are you talking about?");
+
+		tok = lex();			# continue with the rest
+	    }
+
+	    if (tok == IDENT) {			# might be a new rule
+		old_str = tok_str;
+		nxt = lex();			# look ahead
+		unlex(nxt);
+		tok_str = old_str;
+
+		if (nxt == ":")			# yup, a new rule started
+		    break;
+
+		rule_rhs[rule_idx, rule_sub] = rule_rhs[rule_idx, rule_sub]   \
+					       " " tok_str;
+	    } else if (tok == CHAR) {
+		if (tok_str ~ /^@/)
+		    tok_str = transtab[tok_str];
+
+		rule_rhs[rule_idx, rule_sub] = rule_rhs[rule_idx, rule_sub]   \
+					       " " tok_str;
+	    } else if (tok == "{") {		# an action block
+		skip_action();
+	    } else				# can't be part of a rule
+		break;
+	} while (1);
+
+	sub(/^ /, "", rule_rhs[rule_idx, rule_sub]);
+
+	if (rule_rhs[rule_idx, rule_sub] ~				      \
+	    /(^|[^_\.A-Za-z0-9])error($|[^_\.A-Za-z0-9])/) {
+	    DBG(1, rule_lhs[rule_idx] ": " rule_rhs[rule_idx, rule_sub]	      \
+		   " [IGNORED]");
+
+	    rule_rhs[rule_idx, rule_sub] = "";
+	    rule_len[rule_idx]--;
+	} else
+	    DBG(1, rule_lhs[rule_idx] ": " rule_rhs[rule_idx, rule_sub]);
+
+	if (tok == ";")
+	    tok = lex();
+    } while (1);
+}
+
+#
+#  NAME:	is_optional()
+#  DESCRIPTION: check whether the given non-terminal is optional
+#
+function is_optional(idx) {
+    if ((len = rule_len[idx]) <= 1)
+	return 0;
+
+    #
+    # One or more empty rules for a non-terminal indicate that the other  rules
+    # are in fact optional.  There shouldn't be multiple empty rules, but it is
+    # is technically possible.
+    #
+    for (rule_sub = 1; rule_sub <= len; rule_sub++)
+	if (rule_rhs[idx, rule_sub] == "") {
+	    while (++rule_sub <= len)
+		rule_rhs[idx, rule_sub - 1] = rule_rhs[idx, rule_sub];
+
+	    rule_len[idx]--;
+	}
+
+    return rule_len[idx] < len;
+}
+
+#
+#  NAME:	get_prefix()
+#  DESCRIPTION: check whether the given non-terminal has a common prefix
+#
+function get_prefix(idx) {
+    if ((len = rule_len[idx]) <= 1)
+	return 0;
+
+    #
+    # Split up the first rule into tokens.  These will be compared with all the
+    # other rules for this non-terminal.
+    #
+    gp_last = split(rule_rhs[idx, 1], arr);
+    gp_pref = gp_last;
+
+    #
+    # Look for the longest common prefix.
+    #
+    for (rule_sub = 2; rule_sub <= len; rule_sub++) {
+	$0 = rule_rhs[idx, rule_sub];
+	gp_tokc = NF;
+
+	if (gp_tokc < gp_pref)
+	    gp_pref = gp_tokc;
+
+	for (j = 1; j <= gp_pref; j++)
+	    if (arr[j] != $j) {
+		if (!(gp_pref = j - 1))
+		    return 0;
+
+		break;
+	    }
+    }
+
+    #
+    # Construct the prefix string.
+    #
+    gp_pstr = arr[1];
+    for (j = 2; j <= gp_pref; j++)
+	gp_pstr = gp_pstr " " arr[j];
+
+    #
+    # Remove the common prefix from all rules for this non-terminal.
+    #
+    for (rule_sub = 1; rule_sub <= len; rule_sub++) {
+	$0 = rule_rhs[idx, rule_sub];
+
+	for (j = 1; j <= gp_pref; j++)
+	    $j = "";
+
+	sub(/^ +/, "");
+	rule_rhs[idx, rule_sub] = $0;
+    }
+
+    return gp_pstr;
+}
+
+#
+#  NAME:	get_suffix()
+#  DESCRIPTION: check whether the given non-terminal has a common suffix
+#
+function get_suffix(idx) {
+    if ((len = rule_len[idx]) <= 1)
+	return 0;
+
+    #
+    # Split up the first rule into tokens.  These will be compared with all the
+    # other rules for this non-terminal.
+    #
+    gs_last = split(rule_rhs[idx, 1], arr);
+    gs_suff = gs_last;
+
+    #
+    # Look for the longest common suffix.
+    #
+    for (rule_sub = 2; rule_sub <= len; rule_sub++) {
+	$0 = rule_rhs[idx, rule_sub];
+	gs_tokc = NF;
+
+	if (gs_tokc < gs_suff)
+	    gs_suff = gs_tokc;
+
+	for (j = 0; j < gs_suff; j++)
+	    if (arr[gs_last - j] != $(gs_tokc - j)) {
+		if (!(gs_suff = j))
+		    return 0;
+
+		break;
+	    }
+    }
+
+    #
+    # Construct the suffix string.
+    #
+    gs_sstr = arr[gs_last];
+    for (j = 1; j < gs_suff; j++)
+	gs_sstr = arr[gs_last - j] " " gs_sstr;
+
+    #
+    # Remove the common suffix from all rules for this non-terminal.
+    #
+    for (rule_sub = 1; rule_sub <= len; rule_sub++) {
+	$0 = rule_rhs[idx, rule_sub];
+
+	for (j = 0; j < gs_suff; j++)
+	    $(NF - j) = "";
+
+	sub(/ +$/, "");
+	rule_rhs[idx, rule_sub] = $0;
+    }
+
+    return gs_sstr;
+}
+
+#
+#  NAME:	optimize1()
+#  DESCRIPTION: first pass of the optimizer
+#
+function optimize1() {
+    DBG(0, "Optimization pass 1...");
+
+    for (rule_idx = 1; rule_idx <= rule_cnt; rule_idx++) {
+	#
+	# Non-terminals with only a single rule can't be optimized here.
+	#
+	if ((len = rule_len[rule_idx]) <= 1)
+	    continue;
+
+	#
+	# First record whether the entire non-terminal might be optional.
+	#
+	rule_opt[rule_idx] = is_optional(rule_idx);
+
+	#
+	# The actual optimization takes place in this endless loop.  It will in
+	# fact end when an iteration does not yield an optional ruleset.   This
+	# is a proper and correct stop criteria, since a  non-optional  ruleset
+	# cannot have any common prefix or suffix.  If it did, those would have
+	# been added to the already present prefix or suffix.
+	#
+	pref = "";
+	suff = "";
+	do {
+	    if (pstr = get_prefix(rule_idx))
+		pref = pref " " pstr;
+	    else if (sstr = get_suffix(rule_idx))
+		suff = sstr " " suff;
+
+	    if (is_optional(rule_idx)) {
+		pref = pref " [";
+		suff = "] " suff;
+	    } else {
+		if (pstr || sstr) {
+		    pref = pref " (";
+		    suff = ") " suff;
+		}
+
+		break;
+	    }
+	} while (1);
+
+	#
+	# Compose the single composite rule for this non-terminal, if a  common
+	# prefix or suffix was found.
+	#
+	if (pref != "" || suff != "") {
+	    sub(/^ /, "", pref);
+	    sub(/ $/, "", suff);
+
+	    DBG(2, "Rules for '" rule_lhs[rule_idx] "' have:");
+
+	    if (pref != "")
+		DBG(3, "Prefix '" pref "'");
+	    if (suff != "")
+		DBG(3, "Suffix '" suff "'");
+
+	    len = rule_len[rule_idx];
+	    pref = pref " " rule_rhs[rule_idx, 1];
+
+	    for (rule_sub = 2; rule_sub <= len; rule_sub++)
+		pref = pref " | " rule_rhs[rule_idx, rule_sub];
+
+	    rule_rhs[rule_idx, 1] = pref " " suff;
+	    rule_len[rule_idx] = 1;
+
+	    DBG(3, "Combined rule '" rule_rhs[rule_idx, 1] "'");
+
+	    if (rule_opt[rule_idx])
+		DBG(3, "(The non-terminal is optional.)");
+	}
+    }
+}
+
+#
+#  NAME:	optimize2()
+#  DESCRIPTION: second pass of the optimizer
+#
+function optimize2() {
+    DBG(0, "Optimization pass 2...");
+
+    for (rule_idx = 1; rule_idx <= rule_cnt; rule_idx++) {
+	$0 = rule_rhs[rule_idx, 1];
+
+	if ((len = rule_len[rule_idx]) > 1)
+	    for (rule_sub = 2; rule_sub <= len; rule_sub++)
+		$0 = $0 " | " rule_rhs[rule_idx, rule_sub];
+
+	if ($1 != "[" && rule_opt[rule_idx]) {
+	    $0 = "[ " $0 " ]";
+	    rule_opt[rule_idx] = 0;
+	}
+
+	if ($1 == "[")
+	    if ($2 == rule_lhs[rule_idx]) {
+		for (i = NF; i > 0; i--)
+		    if ($i == "]")
+			break;
+
+		if ((NF - i) < 3) {
+		    $1 = "";
+		    subst = "{";
+		    $i = "}";
+
+		    while (++i <= NF)
+			subst = subst " " $i;
+
+		    $2 = subst;
+
+		    sub(/^ +/, "");
+		}
+	    }
+
+	if ($NF == "]")
+	    if ($(NF - 1) == rule_lhs[rule_idx]) {
+		for (i = 1; i <= NF; i++)
+		    if ($i == "[")
+			break;
+
+		if (i < 3) {
+		    $i = "{";
+		    subst = "}";
+		    $NF = "";
+
+		    while (--i > 0)
+			subst = $i " " subst;
+
+		    $(NF - 1) = subst;
+
+		    sub(/ +$/, "");
+		}
+	    }
+
+	if (rule_opt[rule_idx]) {
+	    $0 = "[ " $0 " ]";
+	    rule_opt[rule_idx] = 0;
+	}
+
+	rule_rhs[rule_idx, 1] = $0;
+	rule_len[rule_idx] = 1;
+    }
+}
+
+#
+#  NAME:	latexify()
+#  DESCRIPTION: make substitutions to ensure that the string is LaTeX ok
+#
+function latexify(txt) {
+    gsub(/[{&%}]/, "$\\\\&$", txt);
+    gsub(/[!|[\]=+\-*\/<>]/, "$&$", txt);
+    gsub(/\$\$/, "\\!", txt);
+    gsub(/"[^"]+"/, "``{\\bf &}''", txt);
+    gsub(/_/, "\\_", txt);
+    gsub(/\^/, "\\verb+^+", txt);
+    gsub(/"/, "", txt);
+
+    return txt;
+}
+
+#
+#  NAME:	break_string()
+#  DESCRIPTION: possibly break up a string in multiple lines
+#
+function break_string(str) {
+    match(str, /^([_A-Za-z][_A-Za-z0-9]* +| +)(::=|\|)/);
+    bs_len = RLENGTH;
+    bs_str = substr(str, 1, RLENGTH);
+    bs_pln = RLENGTH;
+    bs_pre = SPACES(RLENGTH);
+
+    $0 = substr(str, RLENGTH + 2);
+    for (i = 1; i <= NF; i++) {
+	if (bs_len + 1 + length($i) > 79) {
+	    bs_str = bs_str "\n" bs_pre;
+	    bs_len = bs_pln;
+	}
+
+	bs_str = bs_str " " $i;
+	bs_len += 1 + length($i);
+   }
+
+    return bs_str;
+}
+
+#
+#  NAME:	output()
+#  DESCRIPTION: write out the rewritten rules
+#
+function output(LaTeX) {
+    rule_use[grammar_start] = 1;
+
+    for (rule_idx = 1; rule_idx <= rule_cnt; rule_idx++) {
+	len = rule_len[rule_idx];
+
+	if (rule_opt[rule_idx]) {
+	    rule_rhs[rule_idx, 1] = "[ "  rule_rhs[rule_idx, 1];
+	    rule_rhs[rule_idx, len] = rule_rhs[rule_idx, len] " ]";
+	}
+
+	str = LaTeX ? latexify(rule_lhs[rule_idx])			      \
+		    : rule_lhs[rule_idx];
+
+	if (length(str) > rule_max) {
+	    rule_max = length(str);
+	    rule_mls = str;
+	}
+
+	for (rule_sub = 1; rule_sub <= len; rule_sub++) {
+	    $0 = rule_rhs[rule_idx, rule_sub];
+
+	    for (j = 1; j <= NF; j++) {
+		#
+		# A couple of notes here...  Non-terminals that merely  have  a
+		# single terminal as definition are substituted  anywhere  they
+		# are used.  And some special casing is needed  for  situations
+		# where someone actually defines the non-terminals  as  tokens.
+		# Those should definitely not be quotated.
+		#
+		if ((idx = rule_ref[$j]) &&
+		    rule_len[$j] == 1 && rule_rhs[idx, 1] ~ /^[^ ]+$/)
+		    $j = rule_rhs[idx, 1];
+		else if ((str = transtab[$j]) && !rule_ref[$j])
+		    $j = str;
+
+		rule_use[$j] = 1;
+	    }
+
+	    rule_rhs[rule_idx, rule_sub] = $0;
+	}
+    }
+
+    if (LaTeX)
+	#
+	# Some LaTeX magic...  We calculate the available size for the  RHS  of
+	# the rules.  This will be provided as argument to the  minipages  used
+	# for each independent rule.
+	#
+	# The formula is fairly easy:
+	#	textwidth - width(LHS) - width("::=") - 6 * tabcolsep
+	#
+	print "\\newlength\\rulelhs\n"					      \
+	      "\\newlength\\rulemid\n"					      \
+	      "\\newlength\\rulerhs\n"					      \
+	      "\\settowidth\\rulelhs{" rule_mls "}\n"			      \
+	      "\\settowidth\\rulemid{::=}\n"				      \
+	      "\\setlength\\rulerhs{\\textwidth}\n"			      \
+	      "\\addtolength\\rulerhs{-\\rulelhs}\n"			      \
+	      "\\addtolength\\rulerhs{-\\rulemid}\n"			      \
+	      "\\addtolength\\rulerhs{-6\\tabcolsep}\n\n"		      \
+	      "\\begin{longtable}{lrl}";
+
+    for (rule_idx = 1; rule_idx <= rule_cnt; rule_idx++) {
+	if (!rule_use[rule_lhs[rule_idx]])
+	    continue;
+
+	len = rule_len[rule_idx];
+
+	for (rule_sub = 1; rule_sub <= len; rule_sub++) {
+	    if (LaTeX) {
+		str = latexify(rule_lhs[rule_idx]);
+		out = str SPACES(rule_max - length(str)) " & ::= &\n"	      \
+		      "  \\begin{minipage}[t]{\\rulerhs}\n"		      \
+		      "    \\raggedright\n    ";
+	    } else {
+		str = rule_lhs[rule_idx];
+		out = str SPACES(rule_max - length(str)) " ::= ";
+	    }
+
+	    rhs = rule_rhs[rule_idx, rule_sub];
+	    lvl = 0;
+
+	    while (match(rhs, /(^[\(\{\[] | [\(\{\[\|\]\}\)] | [\]\}\)]$)/)) {
+		o_beg = RSTART;
+		o_len = RLENGTH;
+
+		if (substr(rhs, o_beg) ~ /(^[\(\{\[] | [\(\{\[] )/) {
+		    lvl++;
+
+		    str = LaTeX ? latexify(substr(rhs, 1, o_beg + o_len - 1)) \
+				: substr(rhs, 1, o_beg + o_len - 1);
+
+		    out = out str;
+		    rhs = substr(rhs, o_beg + o_len);
+		} else if (substr(rhs, o_beg) ~ /( [\]\}\)] | [\]\}\)]$)/) {
+		    lvl--;
+
+		    str = LaTeX ? latexify(substr(rhs, 1, o_beg + o_len - 1)) \
+				: substr(rhs, 1, o_beg + o_len - 1);
+
+		    out = out str;
+		    rhs = substr(rhs, o_beg + o_len);
+		} else if (substr(rhs, o_beg + 1, 1) == "|") {
+		    if (lvl) {
+			out = out substr(rhs, 1, o_beg + o_len - 1);
+			rhs = substr(rhs, o_beg + o_len);
+		    } else {
+			if (LaTeX) {
+			    str = latexify(substr(rhs, 1, o_beg - 1));
+
+			    print out str				      \
+				  SPACES(64 - rule_max - length(str)) "\n"    \
+				  "  \\end{minipage}" SPACES(60) " \\\\";
+
+			    out = SPACES(rule_max) " & $|$ &\n"		      \
+				  "  \\begin{minipage}[t]{\\rulerhs}\n"	      \
+				  "    \\raggedright\n    ";
+			} else {
+			    print break_string(out substr(rhs, 1, o_beg - 1));
+
+			    out = SPACES(rule_max + 1) "  | ";
+			}
+
+			rhs = substr(rhs, o_beg + o_len);
+		    }
+		}
+	    }
+
+	    if (LaTeX) {
+		str = latexify(rhs);
+
+		print out str SPACES(76 - length(out) - length(str)) "\n"     \
+		      "  \\end{minipage}" SPACES(60) " \\\\";
+	    } else
+		print break_string(out rhs);
+	}
+    }
+
+    if (LaTeX)
+	print "\\end{longtable}";
+}
+
+#
+#  NAME:	process()
+#  DESCRIPTION: process a given yacc grammar definition file
+#
+function process(grammar_file) {
+    if (!exists(grammar_file))
+	error("So where exactly is this file?");
+
+    DBG(0, "Reading grammar from '" grammar_file "'.");
+
+    read_declarations();
+    read_grammar();
+
+    if (_optim >= 1)
+	optimize1();
+    if (_optim >= 2)
+	optimize2();
+
+    output(!_plain);
+}
+
+#
+#  NAME:	load_tokens()
+#  DESCRIPTION: load a list of literal tokens from a file
+#
+function load_tokens(file) {
+    while (getline < file == 1)
+	transtab[$1] = "\"" $2 "\"";
+
+    close(file);
+}
+
+#
+#  NAME:	give_help()
+#  DISCRIPTION: offer some help to the poor user
+#
+function give_help() {
+    print "Usage: y2l -- [options] yacc-file\n"				      \
+	  "Options:\n"							      \
+	  "    -d\n"							      \
+	  "\tWrite debugging output to the standard error stream.  One  can\n"\
+	  "\tsupply a numeric argument to this option to set an indentation\n"\
+	  "\tlevel for the messages.\n"					      \
+	  "    -h\n"							      \
+	  "\tDisplay this help information.\n"				      \
+	  "    -O, -O[012]\n"u						      \
+	  "\tOptimize the grammar to get more typical EBNF.  If no argument\n"\
+	  "\tis provided, the highest optimization level is selected.\n"      \
+	  "    -p\n"							      \
+	  "\tGive basic ASCII output rather than LaTeX output.\n"	      \
+	  "    -t/regexp/, -tfile\n"					      \
+	  "\tIn the first form, the regular expression is used  to  decide\n" \
+	  "\twhether a terminal in the grammar is a real token or rather a\n" \
+	  "\tliteral.  The second variant specifies a file which  contains\n" \
+	  "\tlines listing a token and the literal it represents.\n"	      \
+	  "    -v\n"							      \
+	  "\tPrint out version information.";
+    exit;
+}
+
+#
+#  All processing is done from the BEGIN block.  The  one  and  only  mandatory
+#  argument to the program is passed on to the grammar processor.
+#
+BEGIN {
+    _debug = 0;					# no debugging
+    _optim = 0;					# no optimization
+    _plain = 0;					# no plain output
+    _tkpat = 0;					# no token pattern
+
+    _bannr = "Yacc-to-LaTeX grammar processor v1.0";
+
+    for (i = 1; i < ARGC; i++)			# loop over all arguments
+	if (ARGV[i] ~ /^-d$/)			# debugging
+	    _debug = 1;
+	else if (ARGV[i] ~ /^-h$/)		# help the user
+	    give_help();
+	else if (ARGV[i] ~ /^-O([012]|$)/)	# optimization level
+	    if (length(ARGV[i]) > 2)
+		_optim = substr(ARGV[i], 3, 1);
+	    else
+		_optim = 1;			# default optimization level
+	else if (ARGV[i] ~ /^-p$/)		# non-LaTeX output
+	    _plain = 1;
+	else if (ARGV[i] ~ /^-t/)		# regexp or file for tokens
+	    if (ARGV[i] ~ /^-t(\/\^|\/)[_\.A-Za-z][_\.A-zA-z0-9]*(\/|\$\/)$/) {
+		l = length(ARGV[i]);
+		_tkpat = substr(ARGV[i], 4, l - 4);
+	    } else if (exists(file = substr(ARGV[i], 3)))
+		load_tokens(file);
+	    else
+		error("So where is the token regexp pattern or file?");
+	else if (ARGV[i] ~ /^-v$/)		# version
+	    print _bannr					>"/dev/stderr";
+	else if (ARGV[i] ~ /^-/)		# unknown option
+	    error("Am I supposed to do something with '" ARGV[i] "'?");
+	else if (grammar_file)			# more than one grammar
+	    error("How about just processing one grammar at a time?");
+	else
+	    grammar_file = ARGV[i];		# name of the grammar file
+
+    if (!grammar_file)				# no grammar file provided
+	error("Any particular grammar you have in mind?");
+
+    init();					# initialization
+
+    process(grammar_file)			# process the given grammar
+
+    exit;
+}

--- a/doc/grammar_yacc_tools/y2l.license
+++ b/doc/grammar_yacc_tools/y2l.license
@@ -1,0 +1,125 @@
+                      The "Artistic License"
+
+                             Preamble
+
+The intent of this document is to state the conditions under which a
+Package may be copied, such that the Copyright Holder maintains some
+semblance of artistic control over the development of the Package,
+while giving the users of the package the right to use and distribute
+the Package in a more-or-less customary fashion, plus the right to make
+reasonable modifications.
+
+It also grants you the rights to reuse parts of a Package in your own
+programs without transferring this License to those programs, provided
+that you meet some reasonable requirements.
+
+Definitions:
+
+        "Package" refers to the collection of files distributed by the
+        Copyright Holder, and derivatives of that collection of files
+        created through textual modification.
+
+        "Standard Version" refers to such a Package if it has not been
+        modified, or has been modified in accordance with the wishes
+        of the Copyright Holder as specified below.
+
+        "Copyright Holder" is whoever is named in the copyright or
+        copyrights for the package.
+
+        "You" is you, if you're thinking about copying or distributing
+        this Package.
+
+        "Reasonable copying fee" is whatever you can justify on the
+        basis of media cost, duplication charges, time of people involved,
+        and so on.  (You will not be required to justify it to the
+        Copyright Holder, but only to the computing community at large
+        as a market that must bear the fee.)
+
+        "Freely Available" means that no fee is charged for the item
+        itself, though there may be fees involved in handling the item.
+        It also means that recipients of the item may redistribute it
+        under the same conditions they received it.
+
+1. You may make and give away verbatim copies of the source form of the
+Standard Version of this Package without restriction, provided that you
+duplicate all of the original copyright notices and associated disclaimers.
+
+2. You may apply bug fixes, portability fixes and other modifications
+derived from the Public Domain or from the Copyright Holder.  A Package
+modified in such a way shall still be considered the Standard Version.
+
+3. You may otherwise modify your copy of this Package in any way, provided
+that you insert a prominent notice in each changed file stating how and
+when you changed that file, and provided that you do at least ONE of the
+following:
+
+    a) place your modifications in the Public Domain or otherwise make them
+    Freely Available, such as by posting said modifications to Usenet or
+    an equivalent medium, or placing the modifications on a major archive
+    site such as uunet.uu.net, or by allowing the Copyright Holder to include
+    your modifications in the Standard Version of the Package.
+
+    b) use the modified Package only within your corporation or organization.
+
+    c) rename any non-standard executables so the names do not conflict
+    with standard executables, which must also be provided, and provide
+    a separate manual page for each non-standard executable that clearly
+    documents how it differs from the Standard Version.
+
+    d) make other distribution arrangements with the Copyright Holder.
+
+4. You may distribute the programs of this Package in object code or
+executable form, provided that you do at least ONE of the following:
+
+    a) distribute a Standard Version of the executables and library files,
+    together with instructions (in the manual page or equivalent) on where
+    to get the Standard Version.
+
+    b) accompany the distribution with the machine-readable source of
+    the Package with your modifications.
+
+    c) give non-standard executables non-standard names, and clearly
+    document the differences in manual pages (or equivalent), together
+    with instructions on where to get the Standard Version.
+
+    d) make other distribution arrangements with the Copyright Holder.
+
+5. You may charge a reasonable copying fee for any distribution of this
+Package.  You may charge any fee you choose for support of this
+Package.  You may not charge a fee for this Package itself.  However,
+you may distribute this Package in aggregate with other (possibly
+commercial) programs as part of a larger (possibly commercial) software
+distribution provided that you do not advertise this Package as a
+product of your own.
+
+6. The scripts and library files supplied as input to or produced as
+output from the programs of this Package do not automatically fall
+under the copyright of this Package, but belong to whomever generated
+them, and may be sold commercially, and may be aggregated with this
+Package.  If such scripts or library files are aggregated with this
+Package via the so-called "undump" or "unexec" methods of producing a
+binary executable image, then distribution of such an image shall
+neither be construed as a distribution of this Package nor shall it
+fall under the restrictions of Paragraphs 3 and 4, provided that you do
+not represent such an executable image as a Standard Version of this
+Package.
+
+7. You may reuse parts of this Package in your own programs, provided that
+you explicitly state where you got them from, in the source code (and, left
+to your courtesy, in the documentation), duplicating all the associated
+copyright notices and disclaimers. Besides your changes, if any, must be
+clearly marked as such. Parts reused that way will no longer fall under this
+license if, and only if, the name of your program(s) have no immediate
+connection with the name of the Package itself or its associated programs.
+You may then apply whatever restrictions you wish on the reused parts or
+choose to place them in the Public Domain--this will apply only within the
+context of your package.
+
+8. The name of the Copyright Holder may not be used to endorse or promote
+products derived from this software without specific prior written permission.
+
+9. THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+                                The End

--- a/doc/grammar_yacc_tools/y2l.readme
+++ b/doc/grammar_yacc_tools/y2l.readme
@@ -1,0 +1,82 @@
+
+                               Yacc to LaTeX
+     _________________________________________________________________
+   
+Contents
+
+     * What is y2l?
+     * What is the purpose of y2l?
+     * What about portability?
+     * Where to download y2l?
+     * How to use y2l?
+       
+   The master copy of this document is available at the following URL:
+   http://www.alchar.org/~aedil/Projects/y2l.html.
+   
+What is y2l?
+
+   The Yacc to LaTeX utility takes (hopefully) any yacc source file, and
+   derives an Extended Backus-Naur Form (EBNF) description from it. This
+   EBNF is written out as LaTeX source. The output is a LaTeX "longtable"
+   environment, that can be included in any LaTeX document, typically
+   using an \input{} statement.
+   
+What is the purpose of y2l?
+
+   Questions about the purpose of things are so common, so here is the
+   answer to this very frequently asked question. When designing Abyss, I
+   found that I was continuously updating the grammar in two places. The
+   yacc description was of course the final authority. But I made it a
+   point to ensure that I would have decent and up-to-date documentation
+   for the language. Which led to the first incarnation of y2l.
+   
+   Then came the well known moment of truth when that first version was
+   used to try and generate an EBNF description for someone else's
+   grammar. That failed quite miserably because of implicit dependencies
+   on the format of the Abyss grammar description. A new y2l was written,
+   based around a strict yacc source file parser. It is designed to be
+   able to turn any yacc source file into an EBNF description, yet it
+   might choke on some Bison source files, because of large liberties the
+   authors of Bison have taken compared to the "original" yacc. This is
+   considered to be a "known bug" and might be solved in the future.
+   
+What about portability?
+
+   How portable is this little utility? Well, it's pretty portable in the
+   sense that is has been written in good ol' AWK! As long as you have a
+   machine with a sensible AWK (such as Gawk, or the one true AWK on
+   Brian Kernighan's homepage (http://plan9.bell-labs.com/cm/cs/who/bwk),
+   it will work.
+   
+   You may have to manually update the first line of the y2l script to
+   point to the proper AWK executable on your system. Not every system
+   has a sensible AWK as /usr/bin/awk!
+   
+Where to download y2l?
+
+   The latest release of y2l is available here for download
+   (http://y2l.sourceforge.net/download/y2l.tar.gz).
+   
+   The PGP signature for y2l is available at
+   http://y2l.sourceforge.net/download/y2l.tar.gz.asc. The signing key
+   can be found at the author's homepage (http://www.alchar.org/~aedil/).
+   
+   Anonymous read-only CVS access is available from SourceForge. Follow
+   these easy steps:
+     * cvs -d:pserver:anonymous@cvs.y2l.sourceforge.net:/cvsroot/y2l
+       login
+     * cvs -d:pserver:anonymous@cvs.y2l.sourceforge.net:/cvsroot/y2l co
+       y2l
+     * cvs update
+       You can use this in the y2l directory any time you wish to update
+       your local copy against the CVS repository.
+       
+How to use y2l?
+
+   The y2l manual is included in the distribution in Unix manpage format
+   and as an HTML file. The link in this section will bring you to the
+   most current HTML version of the y2l manual.
+     _________________________________________________________________
+   
+                                             Last modified: Mar 7th, 2000
+                                                      ©1995-2000 by Aedil

--- a/examples/nocurses/export_to_mkd.sc
+++ b/examples/nocurses/export_to_mkd.sc
@@ -1,0 +1,7 @@
+label A0 = "Col1"
+label B0 = "Col2"
+let A1=0
+let B1=2
+execute "e! mkd /tmp/test.md"
+quit
+

--- a/examples/nocurses/export_to_mkd.sc
+++ b/examples/nocurses/export_to_mkd.sc
@@ -1,7 +1,7 @@
-label A0 = "Col1"
-label B0 = "Col2"
-let A1=0
-let B1=2
-execute "e! mkd /tmp/test.md"
-quit
+LABEL A0 = "Col1"
+LABEL B0 = "Col2"
+LET A1=0
+LET B1=2
+EXECUTE "e! mkd /tmp/test.md"
+QUIT
 

--- a/examples/nocurses/nocurses.readme
+++ b/examples/nocurses/nocurses.readme
@@ -1,0 +1,18 @@
+These are examples how to run sc-im with the -nocurses option
+
+COMMAND:
+cat examples/nocurses/export_to_mkd.sc | sc-im --nocurses examples/sc/subtotals.sc && cat /tmp/test.md
+
+STDOUT:
+Writing file "/tmp/test.md"...
+File "/tmp/test.md" written
+quitting. unsaved changes will be lost.
+|    Col1    |    Col2    |
+|:----------:|:----------:|
+|       0.00 |       2.00 |
+
+COMMAND:
+echo "let A0=1\nlet A1=1\nlet A2=A0+A1\nrecalc\nexecute \"version\"\n\n"| ./src/sc-im --nocurses --quit_afterload
+
+STDOUT:
+Prints version end waits for quit.

--- a/examples/xlsx/xlsx2markdown.sc
+++ b/examples/xlsx/xlsx2markdown.sc
@@ -1,0 +1,5 @@
+EXECUTE "load str.xlsx"
+EXECUTE "e! mkd str.md"
+ERROR "exporting..."
+quit
+

--- a/src/cmds_command.c
+++ b/src/cmds_command.c
@@ -455,7 +455,10 @@ void do_commandmode(struct block * sb) {
                     delete_structures();
                     create_structures();
                     readfile(name, 0);
-                    ui_show_header();
+
+                    if (! atoi(get_conf_value("nocurses"))) {
+                      ui_show_header();
+                    }
                 }
             }
         } else if ( ! wcsncmp(inputline, L"hiderow ", 8) ||

--- a/src/doc
+++ b/src/doc
@@ -374,6 +374,8 @@ Commands for handling cell content:
                  Like ":e tab", but overwrite {file} if it exists.
                  If a range is selected, only that range is exported.
 
+     :e csv      Export the current spreadsheet to a comma-separated file.
+
      :e csv {file}
                  Export the current spreadsheet to comma-separated file
                  {file}.
@@ -389,7 +391,6 @@ Commands for handling cell content:
 
      :e! txt {file}
                  Like ":e txt", but overwrite {file} if it exists.
-
      :e xlsx {file}
                  Export the current spreadsheet to xlsx file {file}.
                  If 'xlsx_readformulas' is set, SC-IM tries to export

--- a/src/doc
+++ b/src/doc
@@ -364,7 +364,8 @@ Commands for handling cell content:
                  The name of the created file comes from the current
                  spreadsheet, with ".tab" appended.
                  If a range is selected, only that range is exported.
-                 NOTE: If you do an export with the :e command, current file name stays unchaged.
+                 NOTE: If you do an export with the :e command, current file
+                 name stays unchaged.
                  See :file command for more details.
 
      :e tab {file}
@@ -406,8 +407,9 @@ Commands for handling cell content:
                  That value contains a system command that is executed to copy
                  to an specific clipboard. See in Makefile the different
                  options available.
-                 You can also set a different value of 'default_copy_to_clipboard_cmd'
-                 configuration variable at runtime, using the :set command.
+                 You can also set a different value of
+                 'default_copy_to_clipboard_cmd' configuration variable at
+                 runtime, using the :set command.
                  This process will export content as plain text.
                  It will not delimit columns with '\t' chars.
                  If you wish to delimit columns with tabs, to paste content
@@ -416,22 +418,23 @@ Commands for handling cell content:
 
      :cpaste     Paste clipboard content to Sc-im.
                  When 'cpaste' command is executed, the default value of macro
-                 DEFAULT_PASTE_FROM_CLIPBOARD_CMD (set in Makefile during build)
-                 is executed.
+                 DEFAULT_PASTE_FROM_CLIPBOARD_CMD (set in Makefile during
+                 build) is executed.
                  That value contains a system command that is executed to
                  paste content of a specific clipboard to Sc-im.
                  See in Makefile the different options available.
-                 You can also set a different value of 'default_paste_from_clipboard_cmd'
-                 configuration variable at runtime, using the :set command.
-                 This process will treat '\t' chars as column delimiter, and '\n' chars
-                 as rows delimiters.
+                 You can also set a different value of
+                 'default_paste_from_clipboard_cmd' configuration variable at
+                 runtime, using the :set command.
+                 This process will treat '\t' chars as column delimiter, and
+                 '\n' chars as rows delimiters.
 
      :version    Show SC-IM version number.
 
                  If you start Sc-im with ./sc-im --version
                  version number of Sc-im will be printed on screen, including
-                 the different features that were enabled when Sc-im was compiled.
-                 Afterwards Sc-im will exit.
+                 the different features that were enabled when Sc-im was
+                 compiled. Afterwards Sc-im will exit.
 
      :refresh    Refresh the UI. Acts like the <C-l> command of NORMAL_MODE.
 
@@ -672,17 +675,20 @@ Commands for handling cell content:
     :freeze {column}
     :freeze {column:column}
                 Freeze the column or column range given. (Case insensitive).
-                (the rest of the screen scrolls but the column/s stays fixed on the screen).
+                (the rest of the screen scrolls but the column/s stays fixed
+                on the screen).
                 NOTE: there can be only just one frozen range defined.
 
     :freeze {row}
     :freeze {row:row}
                 Freeze the row or row range given.
-                (the rest of the screen scrolls but the row/s stays fixed on the screen).
+                (the rest of the screen scrolls but the row/s stays fixed on
+                the screen).
 
     :freeze {range}
                 Freeze a range given.  (Case insensitive).
-                (the rest of the screen scrolls but the range stays fixed on the screen).
+                (the rest of the screen scrolls but the range stays fixed on
+                the screen).
 
     :unfreeze
                 Remove a previous frozen row / col or range.
@@ -705,7 +711,8 @@ Commands for handling cell content:
                      CELL_FORMAT, CELL_CONTENT, WELCOME, NORMAL, INPUT.
 
                 The value of fg and bg shall be one of the following:
-                     WHITE, BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN or DEFAULT_COLOR.
+                     WHITE, BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN or
+                     DEFAULT_COLOR.
                      DEFAULT_COLOR just takes the default color of your
                      terminal. If you set it as fg color it will take default
                      color of your foreground. If you set it as bg color it
@@ -730,7 +737,8 @@ Commands for handling cell content:
     :unformat
     :unformat {range}
                 Removes a previous format set over a range.
-                If not range is specified, it removes the format over current cell.
+                If not range is specified, it removes the format over current
+                cell.
 
     :redefine_color "{color}" {R} {G} {B}
                 Change the RGB values of the colors defined by ncurses.
@@ -747,8 +755,8 @@ Commands for handling cell content:
                 add it to $HOME/.scimrc:
                             REDEFINE_COLOR "RED" 700 100 100
 
-                Redefining the BLACK color itself is another way to change the default
-                background color of SC-IM.
+                Redefining the BLACK color itself is another way to change the
+                default background color of SC-IM.
 
     :lock       Lock the current cell or range.  Locked cells are immune to
                 any type of editing and can't be changed in any way until
@@ -826,7 +834,8 @@ Commands for handling cell content:
 
     :plot {type}
                 Plot a graphic using a selected range.
-                Right now, only 'line', 'scatter', 'bar' and 'pie' types are allowed.
+                Right now, only 'line', 'scatter', 'bar' and 'pie' types are
+                allowed.
 
                 Ex. of use:     :plot line
                 This command calls gnuplot using the file called 'plotline'
@@ -853,8 +862,9 @@ Commands for handling cell content:
 
     c-p
     <UP>        Go back in command line history.
-                NOTE: if inputline is not empty, up and down keys recall older commands from history,
-                but taking whose commands that beginning matches the current inputline content.
+                NOTE: if inputline is not empty, up and down keys recall older
+                commands from history, but taking whose commands that
+                beginning matches the current inputline content.
 
     c-n
     <DOWN>      Go forward in command line history.
@@ -1029,7 +1039,8 @@ Commands for handling cell content:
     set this to ignore case in searches done with '/' command.
 
     'autobackup' [default 0 (no autobackup)]
-    set this to a number in seconds 'n', to backup current file every 'n' seconds.
+    set this to a number in seconds 'n', to backup current file every 'n'
+    seconds.
     AUTOBACKUP must be set during Sc-im build for this feature to be
     available.
     If you set this to 0 but AUTOBACKUP was set during build, it still will
@@ -1041,9 +1052,9 @@ Commands for handling cell content:
     The following functions return the result of performing an operation on
     all valid (nonblank) entries in the given {range}. The optional second
     argument {expr} is an expression that is to be evaluated for each cell
-    in the specified range to determine which cells to include in the function.
-    Only those cells for which the expression evaluates to true (non-zero)
-    will be used in calculating the value of the function.
+    in the specified range to determine which cells to include in the
+    function. Only those cells for which the expression evaluates to true
+    (non-zero) will be used in calculating the value of the function.
 
 
     @sum({range})
@@ -1293,7 +1304,8 @@ Commands for handling cell content:
 
     @lua("luascript",0)
         Executes a "luascript". Using Lua script scim can be extend with lot
-        new functionality, such as complex programming, accessing databases etc.
+        new functionality, such as complex programming, accessing databases
+        etc.
         The search patch for LUA scripts files is $PWD/lua/
         $HOME/.scim/lua/ or /usr/local/share/scim/lua (in that order)
         Always use it only with @ston see example:
@@ -1346,20 +1358,23 @@ Commands for handling cell content:
 
      Function provided to lua script/triggers :
 
-     sc.lgetnum (c, r)       - get numeric value of cell c,r (c/r is number column/row)
-                               returns value
+     sc.lgetnum (c, r)       - get numeric value of cell c,r (c/r is number
+                               column/row) returns value
      sc.lsetnum (c, r, val)  - set numeric value to a cell c,t
-     sc.lsetform (c, r, str) - set formula to a cell. Basically it does "let cell= str"
+     sc.lsetform (c, r, str) - set formula to a cell. Basically it does "let
+                               cell= str"
      sc.lsetstr(c, r, str)   - set string to a cell
      sc.lgetstr(c, r, str)   - get string from a cell
-     sc.lquery(str)          - query input from user, but first prints str. Use with care!!
+     sc.lquery(str)          - query input from user, but first prints str.
+                               Use with care!!
                                Dont use this function within triggers!!
                                returns string
      sc.sc(str)              - send str to sc-im parser
-     sc.a2colrow(str)        - convert ascii cell representation to numeric column/row
-                               returns column, row example:
+     sc.a2colrow(str)        - convert ascii cell representation to numeric
+                               column/row returns column, row example:
                                c,r=sc.a2colrow("c5")
-     sc.colrow2a(c,r)        - returns ascii representation of numeric column/row
+     sc.colrow2a(c,r)        - returns ascii representation of numeric
+                               column/row
      sc.maxcols()            - return current maximum columns
      sc.maxrows()            - return current maximum rows
      sc.curcol()             - return current column

--- a/src/doc
+++ b/src/doc
@@ -367,7 +367,11 @@ Commands for handling cell content:
                  NOTE: If you do an export with the :e command, current file name stays unchaged.
                  See :file command for more details.
 
-     :e txt      Export current spreadsheet to plain text.
+     :e tab {file}
+                 Export the current spreadsheet to tab-separated file {file}.
+
+     :e! tab {file}
+                 Like ":e tab", but overwrite {file} if it exists.
                  If a range is selected, only that range is exported.
 
      :e csv {file}
@@ -377,11 +381,7 @@ Commands for handling cell content:
      :e! csv {file}
                  Like ":e csv", but overwrite {file} if it exists.
 
-     :e tab {file}
-                 Export the current spreadsheet to tab-separated file {file}.
-
-     :e! tab {file}
-                 Like ":e tab", but overwrite {file} if it exists.
+     :e txt      Export current spreadsheet to plain text.
                  If a range is selected, only that range is exported.
 
      :e txt {file}

--- a/src/doc
+++ b/src/doc
@@ -392,6 +392,19 @@ Commands for handling cell content:
 
      :e! txt {file}
                  Like ":e txt", but overwrite {file} if it exists.
+
+     :e mkd      Export the current spreadsheet to a markdown file solely
+                 containing a single markdown table.
+                 The column alignments come from the cells on the row. All
+                 other alignments are ignored as markdown tables do do not
+                 support cell level alignment.
+
+     :e mkd {file}
+                 Export the current spreadsheet to markdown file {file}.
+
+     :e! mkd {file}
+                 Like ":e mkd", but overwrite {file} if it exists.
+
      :e xlsx {file}
                  Export the current spreadsheet to xlsx file {file}.
                  If 'xlsx_readformulas' is set, SC-IM tries to export

--- a/src/doc
+++ b/src/doc
@@ -340,14 +340,17 @@ Commands for handling cell content:
      :load {file}
                  Load {file} into the SC-IM database.
 
-                 {file} can be an sc format file (.sc), a comma-separated file (.csv),
-                 a tab-separated file (.tab, .tsv), an xlsx or xls file.
+                 {file} can be an sc format file (.sc), a comma-separated file
+                 (.csv), a tab-separated file (.tab, .tsv), an xlsx or xls
+                 file.
 
-                 If loading a csv, tab or tsv file and 'import_delimited_as_text' configuration variable is set
+                 If loading a csv, tab or tsv file and
+                 'import_delimited_as_text' configuration variable is set
                  Sc-im will import numbers as text.
 
-                 If loading an xlsx file and 'xlsx_readformulas' is set, Sc-im will try to import
-                 formulas, rather than the final values of a cell.
+                 If loading an xlsx file and 'xlsx_readformulas' is set, Sc-im
+                 will try to import formulas, rather than the final values of
+                 a cell.
 
      :load! {file}
                  Same as previous, but ignore changes done to the current

--- a/src/doc
+++ b/src/doc
@@ -1367,38 +1367,39 @@ Commands for handling cell content:
 
 ==============================================================================
 &LUA Scripts and Triggers&
-     SC-IM was extended with LUA capabilities and also provided with helper
-     Function for manipulate SC-IM data with Lua at runtime. Since it is a
-     fully functional Lua, you can use all Lua packages also for sc-im lua
-     scripts. Use luarocks to install additional packages.
 
-     Function provided to lua script/triggers :
+        SC-IM was extended with LUA capabilities and also provided with helper
+        Function for manipulate SC-IM data with Lua at runtime. Since it is a
+        fully functional Lua, you can use all Lua packages also for sc-im lua
+        scripts. Use luarocks to install additional packages.
 
-     sc.lgetnum (c, r)       - get numeric value of cell c,r (c/r is number
-                               column/row) returns value
-     sc.lsetnum (c, r, val)  - set numeric value to a cell c,t
-     sc.lsetform (c, r, str) - set formula to a cell. Basically it does "let
-                               cell= str"
-     sc.lsetstr(c, r, str)   - set string to a cell
-     sc.lgetstr(c, r, str)   - get string from a cell
-     sc.lquery(str)          - query input from user, but first prints str.
-                               Use with care!!
-                               Dont use this function within triggers!!
-                               returns string
-     sc.sc(str)              - send str to sc-im parser
-     sc.a2colrow(str)        - convert ascii cell representation to numeric
-                               column/row returns column, row example:
-                               c,r=sc.a2colrow("c5")
-     sc.colrow2a(c,r)        - returns ascii representation of numeric
-                               column/row
-     sc.maxcols()            - return current maximum columns
-     sc.maxrows()            - return current maximum rows
-     sc.curcol()             - return current column
-     sc.currow()             - return current row
+        Function provided to lua script/triggers :
 
-     The search patch for LUA scripts files is $PWD/lua or
-     $HOME/.scim/lua/ or /usr/local/share/scim/lua (in that order)
-     Example can be found in sc-im/examples/lua in source code tree.
+        sc.lgetnum (c, r)       - get numeric value of cell c,r (c/r is number
+                                  column/row) returns value
+        sc.lsetnum (c, r, val)  - set numeric value to a cell c,t
+        sc.lsetform (c, r, str) - set formula to a cell. Basically it does "let
+                                  cell= str"
+        sc.lsetstr(c, r, str)   - set string to a cell
+        sc.lgetstr(c, r, str)   - get string from a cell
+        sc.lquery(str)          - query input from user, but first prints str.
+                                  Use with care!!
+                                  Dont use this function within triggers!!
+                                  returns string
+        sc.sc(str)              - send str to sc-im parser
+        sc.a2colrow(str)        - convert ascii cell representation to numeric
+                                  column/row returns column, row example:
+                                  c,r=sc.a2colrow("c5")
+        sc.colrow2a(c,r)        - returns ascii representation of numeric
+                                  column/row
+        sc.maxcols()            - return current maximum columns
+        sc.maxrows()            - return current maximum rows
+        sc.curcol()             - return current column
+        sc.currow()             - return current row
+
+        The search patch for LUA scripts files is $PWD/lua or
+        $HOME/.scim/lua/ or /usr/local/share/scim/lua (in that order)
+        Example can be found in sc-im/examples/lua in source code tree.
 
 
 ==============================================================================
@@ -1482,4 +1483,238 @@ Commands for handling cell content:
 
     Note: Setting the --output parameter implies setting the --nocurses flag.
 
- vim:tw=78:ts=8:ft=help:norl:
+    SC-IM script function names are case insensitive.
+       'LET A0=1' is the same as 'let A0=1'
+
+    Almost every interactive SC-IM command is available for non-interactive
+    scripting. Search the equivelent interactive commands for usage
+    information.
+
+    SC-IM has these commands for available for external scripts.
+
+    LET {[COL][ROW]}={expr}
+        Sets the contents of a cell with a value or an expression. E.g.
+        'LET A1=A2*A2'
+
+    LABEL {[COL][ROW]}={expr}
+        Sets the label of a cell with to a string value.
+
+    EXECUTE "{STRING}"
+        Call an internal COMMAND MODE command. Examples:
+        EXECUTE "load! /tmp/test.xls"
+        EXECUTE "e! mkd /path/test.md"
+
+    RECALC
+        Recalculates a formulas in all cells
+
+    GETNUM {[COL][ROW]}
+        Get numeric value from cell and print to STDOUT
+
+    GETSTRING {[COL][ROW]}
+        Get text value from cell and print to STDOUT
+
+    GETEXP {[COL][ROW]}
+        Get expression from cell and print to STDOUT
+
+    GETFORMAT {COL}
+        Get format from cell and print to STDOUT
+
+    GETFMT {[COL][ROW]}
+        Get format from cell and print to STDOUT
+
+    QUIT
+        Quits SC-IM.
+
+    Other available commands for scripting are:
+
+    DETAIL {var}
+    LEFTSTRING {var_or_range}
+    RIGHTSTRING {var_or_range}
+    LEFTJUSTIFY {var_or_range}
+    RIGHTJUSTIFY {var_or_range}
+    CENTER {var_or_range}
+    FORMAT {COL} {NUMBER} {NUMBER} {NUMBER}
+    FMT {var_or_range} {STRING}
+    DATEFMT {var_or_range} {STRING}
+    DATEFMT {STRING}
+    HIDE {COL}
+    HIDE {NUMBER}
+    SHOW {COL}
+    SHOW {NUMBER}
+    HIDECOL {COL}
+    SHOWCOL {COL}
+    HIDEROW {NUMBER}
+    SHOWROW {NUMBER}
+    SHOWCOL {COL} : {COL}
+    SHOWROW {NUMBER} : {NUMBER}
+    HIDECOL {COL} : {COL}
+    HIDEROW {NUMBER} : {NUMBER}
+    SHIFT {var_or_range} {STRING}
+    MARK {COL} {var_or_range}
+    MARK {COL} {var_or_range} {var_or_range}
+    FILL {var_or_range} {num} {num}
+    FILL {num} {num}
+    UNFREEZE
+    FREEZE {range}
+    FREEZE {NUMBER} : {NUMBER}
+    FREEZE {NUMBER}
+    FREEZE {COL} : {COL}
+    FREEZE {COL}
+    SORT {range} {STRING}
+    SUBTOTAL {range} {COL} {STRING} {COL}
+    RSUBTOTAL {range} {COL} {STRING} {COL}
+    FILTERON {range}
+    AUTOJUS {COL} : {COL}
+    AUTOJUS {COL}
+    GOTO {var_or_range} {var_or_range}
+    GOTO {var_or_range}
+    GOTO {num}
+    GOTO {STRING}
+    GOTO # {STRING}
+    GOTO % {STRING}
+    CCOPY {range}
+    CPASTE
+    LOCK {var_or_range}
+    UNLOCK {var_or_range}
+    NMAP {STRING} {STRING}
+    IMAP {STRING} {STRING}
+    NNOREMAP {STRING} {STRING}
+    INOREMAP {STRING} {STRING}
+    NUNMAP {STRING}
+    IUNMAP {STRING}
+    COLOR {STRING}
+    CELLCOLOR {var_or_range} {STRING}
+    TRIGGER {var_or_range} {STRING}
+    UNTRIGGER {var_or_range}
+    CELLCOLOR {STRING}
+    UNFORMAT {var_or_range}
+    UNFORMAT
+    REDEFINE_COLOR {STRING} {NUMBER} {NUMBER} {NUMBER}
+    FCOPY
+    FCOPY {strarg}
+    FSUM
+    PAD {NUMBER} {COL} : {COL}
+    PAD {NUMBER} {COL}
+    PAD {NUMBER} {var_or_range}
+    PLOT {STRING} {var_or_range}
+    SET {setlist}
+    DEFINE {strarg} {range}
+    DEFINE {strarg} {var}
+    UNDEFINE {var_or_range}
+    EVAL{expr}
+    REBUILD_GRAPH
+    PRINT_GRAPH
+    SYNCREFS
+    UNDO
+    REDO
+    SEVAL{expr}
+    ERROR {STRING}
+
+    The commands below can be used for calculations.
+
+    @MONTH ({expr})
+    @DAY ({expr})
+    @YEAR ({expr})
+    @NOW
+    @DTS ({expr},{expr},{expr})
+    {NUMBER} . {NUMBER} . {NUMBER}
+    @TTS ({expr},{expr},{expr})
+    @STON ({expr})
+    @SLEN ({expr})
+    @EQS ({expr},{expr})
+    @DATE ({expr})
+    @DATE ({expr},{expr})
+    @FMT ({expr},{expr})
+    @UPPER ({expr})
+    @LOWER ({expr})
+    @CAPITAL ({expr})
+    @INDEX ( {range} ,{expr})
+    @INDEX ({expr}, {range} )
+    @INDEX ( {range} ,{expr},{expr})
+    @LOOKUP ( {range} ,{expr})
+    @LOOKUP ({expr}, {range} )
+    @HLOOKUP ( {range} ,{expr},{expr})
+    @HLOOKUP ({expr}, {range} ,{expr})
+    @VLOOKUP ( {range} ,{expr},{expr})
+    @VLOOKUP ({expr}, {range} ,{expr})
+    @STINDEX ( {range} ,{expr})
+    @STINDEX ({expr}, {range} )
+    @STINDEX ( {range} ,{expr},{expr})
+    @EXT ({expr},{expr})
+    @LUA ({expr},{expr})
+    @NVAL ({expr},{expr})
+    @SVAL ({expr},{expr})
+    @REPLACE ({expr},{expr},{expr})
+    @SUBSTR ({expr},{expr},{expr})
+    FNUMBER
+    @PI
+    @FILENAME ({expr})
+    @MYROW
+    @MYCOL
+    @LASTROW
+    @LASTCOL
+    @COLTOA ({expr})
+    @ASCII ({expr})
+    @SET8BIT ({expr})
+    @CHR ({expr})
+    @ERR
+    ERR
+    @REF
+    REF
+
+    The commands below set runtime configuration values:
+
+    OVERLAP = {NUMBER}
+    OVERLAP
+    NOOVERLAP
+    AUTOBACKUP = {NUMBER}
+    NOAUTOBACKUP
+    AUTOCALC
+    AUTOCALC = {NUMBER}
+    NOAUTOCALC
+    DEBUG
+    DEBUG = {NUMBER}
+    NODEBUG
+    TRG
+    TRG = {NUMBER}
+    NOTRG
+    EXTERNAL_FUNCTIONS
+    EXTERNAL_FUNCTIONS = {NUMBER}
+    NOEXTERNAL_FUNCTIONS
+    HALF_PAGE_SCROLL
+    HALF_PAGE_SCROLL = {NUMBER}
+    NOHALF_PAGE_SCROLL
+    QUIT_AFTERLOAD
+    QUIT_AFTERLOAD = {NUMBER}
+    NOQUIT_AFTERLOAD
+    XLSX_READFORMULAS
+    XLSX_READFORMULAS = {NUMBER}
+    NOXLSX_READFORMULAS
+    NOCURSES
+    NOCURSES = {NUMBER}
+    CURSES
+    NUMERIC
+    NUMERIC = {NUMBER}
+    NONUMERIC
+    IGNORECASE
+    IGNORECASE = {NUMBER}
+    NOIGNORECASE
+    NUMERIC_DECIMAL
+    NUMERIC_DECIMAL = {NUMBER}
+    NONUMERIC_DECIMAL
+    NUMERIC_ZERO
+    NUMERIC_ZERO = {NUMBER}
+    NONUMERIC_ZERO
+    NEWLINE_ACTION
+    NEWLINE_ACTION = {WORD}
+    DEFAULT_COPY_TO_CLIPBOARD_CMD = {strarg}
+    DEFAULT_PASTE_FROM_CLIPBOARD_CMD = {strarg}
+    COPY_TO_CLIPBOARD_DELIMITED_TAB
+    COPY_TO_CLIPBOARD_DELIMITED_TAB = {NUMBER}
+    NOCOPY_TO_CLIPBOARD_DELIMITED_TAB
+    NEWLINE_ACTION = {NUMBER}
+    TM_GMTOFF
+    TM_GMTOFF = {num}
+
+
+vim:tw=78:ts=8:ft=help:norl:

--- a/src/file.c
+++ b/src/file.c
@@ -1155,7 +1155,7 @@ void do_export(int r0, int c0, int rn, int cn) {
 
 void export_markdown(char * fname, int r0, int c0, int rn, int cn) {
     FILE * f;
-    int row, col,hcol;
+    int row, col;
     register struct ent ** pp;
     int pid;
     wchar_t out[FBUFLEN] = L"";

--- a/src/main.c
+++ b/src/main.c
@@ -334,7 +334,7 @@ int main (int argc, char ** argv) {
 
         // if we are not in ncurses
         } else if (fgetws(nocurses_buffer, BUFFERSIZE, f) != NULL) {
-            sc_info("Interp will receive: %ls", nocurses_buffer);
+            sc_debug("Interp will receive: %ls", nocurses_buffer);
             send_to_interp(nocurses_buffer);
         }
 
@@ -397,7 +397,7 @@ void read_stdin() {
     if (select(1, &readfds, NULL, NULL, &timeout)) {
         //sc_debug("there is data");
         while (f != NULL && fgetws(stdin_buffer, BUFFERSIZE, f) != NULL) {
-            sc_info("Interp will receive: %ls", stdin_buffer);
+            sc_debug("Interp will receive: %ls", stdin_buffer);
             send_to_interp(stdin_buffer);
         }
         fflush(f);


### PR DESCRIPTION
New summary:
- merge #381 (doc about markdown export)
- add tools for generating command lists from gram.y to be used in src/doc
- updated ./src/doc
   - format cleanup (wrap too long lines)
- add the EXECUTE command in gram.y for no interactive scripting
   - add documentation and examples
- resolved conflicts with #360 