### PR TITLE
Add --notty. Allow to be called without a /dev/tty device.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -68,6 +68,7 @@ void store_default_config_values() {
     put(user_conf_d, "autocalc", "1");
     put(user_conf_d, "numeric", "0");
     put(user_conf_d, "nocurses", "0");
+    put(user_conf_d, "notty", "0");
     put(user_conf_d, "newline_action", "j");
     put(user_conf_d, "external_functions", "0");
     put(user_conf_d, "xlsx_readformulas", "0");

--- a/src/file.c
+++ b/src/file.c
@@ -1263,10 +1263,12 @@ void export_markdown(char * fname, int r0, int c0, int rn, int cn) {
     }
     closefile(f, pid, 0);
 
-    if (! pid) {
-        sc_info("File \"%s\" written", fname);
+    if (fname != NULL) {
+        closefile(f, pid, 0);
+        if (! pid) {
+            sc_info("File \"%s\" written", fname);
+        }
     }
-
 }
 /**
  * \brief Export to plain TXT

--- a/src/main.c
+++ b/src/main.c
@@ -429,8 +429,10 @@ void read_stdin() {
     if (f != NULL) fclose(f);
 
     if ( ! freopen("/dev/tty", "rw", stdin)) {
+      if (! atoi((char *) get_conf_value("notty"))) {
         perror(NULL);
         exit(-1);
+      }
     }
     //sc_debug("finish reading");
 }
@@ -842,14 +844,15 @@ void show_usage_and_quit(){
 \n  --ignorecase                Set variable 'ignorecase'\
 \n  --import_delimited_as_text Import text as\
 \n  --newline_action={j or l}   Set variable 'newline_action'\
-\n  --nocurses                  Run interactive but without ncurses interface.\
+\n  --nocurses                  Run but without ncurses interface\
+\n  --notty                     Run without /dev/tty device, e.g. GVIM\
 \n  --numeric                   Set variable 'numeric'\
 \n  --numeric_decimal           Set variable 'numeric_decimal'\
 \n  --output=FILE               Save the results in FILE\
 \n  --overlap                   Set variable 'overlap variable'\
 \n  --quit_afterload            Quit after loading all the files\
-\n  --sheet=SHEET               Open SHEET when loading xlsx file. Default is 1.\
-\n  --tm_gmtoff={seconds}       set gmt offset used for converting datetimes to localtime.\
+\n  --sheet=SHEET               Open SHEET when loading xlsx file. Default is 1\
+\n  --tm_gmtoff={seconds}       set gmt offset used for converting datetimes to localtime\
 \n  --txtdelim={\",\" or \";\" or \"\\t\"}  Sets delimiter when opening a .tab of .scv file");
 #ifdef XLSX
   printf("\n\


### PR DESCRIPTION
Add's the --notty option to allow running inside MacVim in combination with nocurses. MacVim and  other gvim's do not have a tty device. When sc-im is called from inside a system() function it raises a system error "device not configured". This option fixes this problem by ignoring this check.

also added a small fix for the export_mkd function.

