### PR TITLE
read stdin after file loading

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -282,12 +282,12 @@ int main (int argc, char ** argv) {
     // 2. loadrc
     loadrc();
 
-    // 3. check input from stdin (pipeline)
+    // 3. read sc file passed as argv
+    load_sc();
+
+    // 4. check input from stdin (pipeline)
     // and send it to interp
     read_stdin();
-
-    // 4. read sc file passed as argv
-    load_sc();
 
     // change curmode to NORMAL_MODE
     chg_mode('.');
@@ -576,6 +576,7 @@ void read_argv(int argc, char ** argv) {
 
 void load_sc() {
     char name[PATHLEN];
+    strcpy(name, ""); //force name to be empty
     #ifdef NO_WORDEXP
     size_t len;
     #else


### PR DESCRIPTION
Currently when stdin is given is overwrites the file contents. This PR enables sc-im to load a file and afterwards apply commands from stdin. I needed to fix a problem at 579 to make this work.

Here's an example how to use it. [demo.sc.zip](https://github.com/andmarti1424/sc-im/files/4182375/demo.sc.zip)
(PR #390 with the extra command's is needed for this to work)

```
echo "VALUEIZEALL\nDELETECOL C\n" |sc-im  --nocurses --export_mkd --quit_afterload demo.sc
```

