### PR TITLE
Add several paths for config file

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -134,11 +134,15 @@ void erasedb() {
 }
 
 /*
- * Search path for scimrc:
+ * \brief Loads config file
+ *
+ * \detail Search path for scimrc:
  * 1. $XDG_CONFIG_HOME/scim/scimrc (only when wordexp enabled)
  * 2. $XDG_CONFIG_HOME/scimrc (only when wordexp enabled)
  * 3. $HOME/.scim/scimrc
  * 4. $HOME/.scimrc
+ *
+ * \return none
  */
 
 void loadrc(void) {

--- a/src/sc-im.1
+++ b/src/sc-im.1
@@ -235,6 +235,24 @@ Use SC-IM as a non-interactive calculator, reading its input from a external scr
 The idea is that the program can be identified as another
 vim-like app. SC-IM stands for Spreadsheet Calculator Improvised.
 .
+.
+.SH CONFIG
+SC-IM searches for config file in the following order:
+.IP 1.
+.B
+$XDG_CONFIG_HOME/scim/scimrc
+(with wordexp enabled)
+.IP 2.
+.B
+$XDG_CONFIG_HOME/scimrc
+(with wordexp enabled)
+.IP 3.
+.B
+$HOME/.scim/scimrc
+.IP 4.
+.B
+$HOME/.scimrc
+.
 .SH AUTHOR
 Written by Andrés Martinelli and collaborators.
 Original man page by Daniel Campoverde.

--- a/src/sc-im.1
+++ b/src/sc-im.1
@@ -241,11 +241,17 @@ SC-IM searches for config file in the following order:
 .IP 1.
 .B
 $XDG_CONFIG_HOME/scim/scimrc
-(with wordexp enabled)
+(defaults to
+.B
+$HOME/.config/scim/scimrc
+)
 .IP 2.
 .B
 $XDG_CONFIG_HOME/scimrc
-(with wordexp enabled)
+(defaults to
+.B
+$HOME/.config/scimrc
+)
 .IP 3.
 .B
 $HOME/.scim/scimrc
@@ -253,6 +259,18 @@ $HOME/.scim/scimrc
 .B
 $HOME/.scimrc
 .
+.PP
+Example of config file:
+
+.RS 4
+.nf
+\fB
+set autocalc
+set numeric
+set numeric_decimal=0
+set overlap
+set xlsx_readformulas
+
 .SH AUTHOR
 Written by Andrés Martinelli and collaborators.
 Original man page by Daniel Campoverde.


### PR DESCRIPTION
# Add several paths for config file

Add support for **XDG_CONFIG_HOME** to conform with XDG Base directory specs.
The order for config search is the following:
+ **$XDG_CONFIG_HOME/scim/scimrc** (fallbacks to **$HOME/.config/scim/scimrc**)
+ **$XDG_CONFIG_HOME/scimrc** (fallbacks to **$HOME/.config/scimrc**)
+ **$HOME/.scim/scimrc**
+ **$HOME/.scimrc**

Also add config example from README to man page