### PR TITLE
Avoid using `&&` in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -189,7 +189,7 @@ $(name)qref: sc.h
 $(OBJS) : y.tab.h experres.h statres.h
 
 y.tab.h : gram.y gram.c
-	test -f y.tab.c && mv y.tab.c gram.c
+	if test -f y.tab.c; then mv y.tab.c gram.c; fi
 
 gram.c : gram.y
 	$(YACC) -d $<


### PR DESCRIPTION
Using `test -f y.tab.c && mv ...` in the Makefile causes `make`
to exit with a non-zero exit code in case the file does not exist.
This can lead to issues with automating builds.