### PR TITLE
Add -fcommon option to CFLAGS in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -24,6 +24,7 @@ CONFIG_DIR= .config
 LDLIBS += -lm
 
 CFLAGS += -Wall -g
+CFLAGS += -fcommon
 CFLAGS += -DNCURSES
 CFLAGS += -D_XOPEN_SOURCE_EXTENDED -D_GNU_SOURCE
 CFLAGS += -DSNAME=\"$(name)\"


### PR DESCRIPTION
`-fcommon` was default till GCC 8.
GCC 10 switched to `-fno-common` (https://gcc.gnu.org/gcc-10/changes.html).
This causes "multiple definitions" linker error for ucolors variable.

This fixes #397 and #411 