### PR TITLE
Make compilation work with gcc 10's -fno-common

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -188,14 +188,15 @@ $(name)qref: sc.h
 
 $(OBJS) : y.tab.h experres.h statres.h
 
+.INTERMEDIATE: y.tab.c
+
 y.tab.c: gram.y
 	$(YACC) -d $<
 
-y.tab.h:	y.tab.c
-	touch $@
+y.tab.h: gram.y | y.tab.c
 
-gram.c:	y.tab.c
-	mv $< $@
+gram.c:	gram.y | y.tab.c
+	mv $| $@
 
 pvmtbl.o: sc.h pvmtbl.c
 	$(CC) ${CFLAGS} -c -DPSC pvmtbl.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -188,11 +188,14 @@ $(name)qref: sc.h
 
 $(OBJS) : y.tab.h experres.h statres.h
 
-y.tab.h : gram.c
-
-gram.c : gram.y
+y.tab.c: gram.y
 	$(YACC) -d $<
-	test -f y.tab.c && mv y.tab.c gram.c
+
+y.tab.h:	y.tab.c
+	touch $@
+
+gram.c:	y.tab.c
+	mv $< $@
 
 pvmtbl.o: sc.h pvmtbl.c
 	$(CC) ${CFLAGS} -c -DPSC pvmtbl.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -188,11 +188,11 @@ $(name)qref: sc.h
 
 $(OBJS) : y.tab.h experres.h statres.h
 
-y.tab.h : gram.y gram.c
-	test -f y.tab.c && mv y.tab.c gram.c
+y.tab.h : gram.c
 
 gram.c : gram.y
 	$(YACC) -d $<
+	test -f y.tab.c && mv y.tab.c gram.c
 
 pvmtbl.o: sc.h pvmtbl.c
 	$(CC) ${CFLAGS} -c -DPSC pvmtbl.c

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -65,7 +65,7 @@
 #endif
 
 void syncref(register struct enode *e);
-extern unsigned int shall_quit;
+extern int shall_quit;
 char insert_edit_submode;
 struct ent * freeents = NULL; // keep deleted ents around before sync_refs
 wchar_t interp_line[BUFFERSIZE];

--- a/src/cmds_command.c
+++ b/src/cmds_command.c
@@ -81,7 +81,7 @@ extern char * rev;
 extern struct dictionary * user_conf_d;
 
 wchar_t inputline[BUFFERSIZE];
-wchar_t interp_line[BUFFERSIZE];
+extern wchar_t interp_line[BUFFERSIZE];
 int inputline_pos; /**< Position in window. Some chars has 2 chars width */
 // see https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms
 int real_inputline_pos; /**<  Real position in inputline */

--- a/src/cmds_normal.c
+++ b/src/cmds_normal.c
@@ -70,7 +70,7 @@ extern int cmd_multiplier;
 extern void start_visualmode(int tlrow, int tlcol, int brrow, int brcol);
 extern void ins_in_line(wint_t d);
 
-wchar_t interp_line[BUFFERSIZE];
+extern wchar_t interp_line[BUFFERSIZE];
 
 #ifdef HISTORY_FILE
 extern struct history * commandline_history;

--- a/src/cmds_visual.c
+++ b/src/cmds_visual.c
@@ -440,7 +440,7 @@ void do_visualmode(struct block * buf) {
             sc_error("Locked cells encountered. Nothing changed");
             return;
         }
-        wchar_t interp_line[BUFFERSIZE];
+        extern wchar_t interp_line[BUFFERSIZE];
         if (buf->value == L'{')      swprintf(interp_line, BUFFERSIZE, L"leftjustify %s", v_name(r->tlrow, r->tlcol));
         else if (buf->value == L'}') swprintf(interp_line, BUFFERSIZE, L"rightjustify %s", v_name(r->tlrow, r->tlcol));
         else if (buf->value == L'|') swprintf(interp_line, BUFFERSIZE, L"center %s", v_name(r->tlrow, r->tlcol));

--- a/src/color.c
+++ b/src/color.c
@@ -60,6 +60,8 @@
 #include "conf.h"
 #include "cmds.h"
 
+struct ucolor ucolors[N_INIT_PAIRS] = {};
+
 static struct dictionary * d_colors_param = NULL;
 
 struct dictionary * get_d_colors_param() {

--- a/src/color.h
+++ b/src/color.h
@@ -57,7 +57,7 @@ struct ucolor {
     int blink;
 };
 
-struct ucolor ucolors[N_INIT_PAIRS];
+extern struct ucolor ucolors[N_INIT_PAIRS];
 
 struct dictionary * get_d_colors_param();
 void start_default_ucolors();

--- a/src/filter.c
+++ b/src/filter.c
@@ -60,6 +60,7 @@
 static int howmany = 0;      /**< how many filters were definedi */
 static int active = 0;       /**< indicates if those filters are applied or not */
 static int * results = NULL; /**< this keeps the results of the applied filters */
+static struct filter_item * filters = NULL;
 
 /**
  * \brief Add a filter to filters structure

--- a/src/filter.h
+++ b/src/filter.h
@@ -44,7 +44,7 @@
 
 struct filter_item {
     char * eval;
-} * filters;
+};
 
 void show_filters();
 void add_filter(char * criteria);

--- a/src/input.c
+++ b/src/input.c
@@ -67,7 +67,6 @@ int cmd_multiplier = 0;    // Multiplier
 int cmd_pending = 0;       // Command pending
 int cmd_digraph = 0;
 static wint_t digraph;
-int shall_quit;            // Break loop if ESC key is pressed
 
 /**
  * \brief Reads stdin for a valid command

--- a/src/tui.c
+++ b/src/tui.c
@@ -103,7 +103,6 @@ WINDOW * main_win;
 WINDOW * input_win;
 SCREEN * sstderr;
 SCREEN * sstdout;
-srange * ranges;
 
 /**
  * \brief Called to start UI


### PR DESCRIPTION
gcc 10 enables -fno-common by default, disabling automatic merging of same-name variables. Variables must be declared extern in the headers and defined in only one .c file.