### PR TITLE
Use yacc -o to eliminate y.tab.c renaming.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 *.o
-src/y.tab.h
-src/experres.h
-src/gram.c
 src/sc-im
+src/gram.h
+src/gram.c
+src/experres.h
 src/statres.h
 doc/grammar_yacc_tools/commands.txt
 doc/grammar_yacc_tools/setitems.txt

--- a/src/Makefile
+++ b/src/Makefile
@@ -186,22 +186,21 @@ $(name) : $(OBJS)
 $(name)qref: sc.h
 	$(CC) $(CFLAGS) $(LDFLAGS) -DQREF $(QREF_FMT) -DSCNAME=\"$(name)\" -o $(name)qref help.c $(LDLIBS)
 
-$(OBJS) : y.tab.h experres.h statres.h
+$(OBJS) : Makefile gram.h experres.h statres.h
 
-y.tab.h : gram.y gram.c
-	if test -f y.tab.c; then mv y.tab.c gram.c; fi
+gram.h : gram.y | gram.c
 
 gram.c : gram.y
-	$(YACC) -d $<
+	$(YACC) -d $< -o $@
 
 pvmtbl.o: sc.h pvmtbl.c
 	$(CC) ${CFLAGS} -c -DPSC pvmtbl.c
 
-experres.h : gram.y
-	sed -f eres.sed < gram.y > experres.h
+experres.h : gram.y eres.sed
+	sed -f eres.sed < $< > $@
 
-statres.h : gram.y
-	sed -f sres.sed < gram.y > statres.h
+statres.h : gram.y sres.sed
+	sed -f sres.sed < $< > $@
 
 docs:
 	doxygen Doxyfile
@@ -217,7 +216,7 @@ man_uninstall:
 
 clean:
 	rm -f $(OBJS)
-	rm -f *res.h y.tab.h
+	rm -f experres.h statres.h gram.h
 	rm -f core gram.c y.output pxmalloc.c pvmtbl.c tags $(name)qref
 	rm -f qhelp.c $(name)
 	rm -rf ../docs/ 

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -57,7 +57,7 @@
 #include "xmalloc.h" // for scxfree
 #include "vmtbl.h"   // for growtbl
 #include "utils/string.h" // for add_char
-#include "y.tab.h"   // for yyparse
+#include "gram.h"   // for yyparse
 #include "dep_graph.h"
 #include "freeze.h"
 #ifdef UNDO

--- a/src/file.c
+++ b/src/file.c
@@ -71,7 +71,7 @@
 #include "utils/dictionary.h"
 #include "cmds_edit.h"
 #include "xmalloc.h"
-#include "y.tab.h"
+#include "gram.h"
 #include "xlsx.h"
 #include "xls.h"
 #include "tui.h"

--- a/src/lex.c
+++ b/src/lex.c
@@ -61,7 +61,7 @@
 typedef int bool;
 enum { false, true };
 
-#include "y.tab.h"
+#include "gram.h"
 
 jmp_buf wakeup;
 jmp_buf fpe_buf;


### PR DESCRIPTION
I checked the BSD yacc man page, it being the most primitive system still in use, and yacc does indeed support the -o option. I previously thought this was just for bison. This allows compiling gram.y directly into gram.c and gram.h, eliminating the mv trickery in the Makefile. I added gram.y dependency to gram.h and an order dependency on gram.c, which will hopefully result in always knowing how to create gram.h. And I added dependencies on the .sed files for the headers generated from gram.y .