### PR TITLE
Show filename in status

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -75,7 +75,7 @@ void store_default_config_values() {
     put(user_conf_d, "quit_afterload", "0");
     put(user_conf_d, "numeric_zero", "1");
     put(user_conf_d, "numeric_decimal", "1");
-    put(user_conf_d, "filename_in_status", "0");
+    put(user_conf_d, "filename_with_mode", "0");
     put(user_conf_d, "overlap", "0");
     put(user_conf_d, "truncate", "0");
     put(user_conf_d, "debug", "0");

--- a/src/conf.c
+++ b/src/conf.c
@@ -75,6 +75,7 @@ void store_default_config_values() {
     put(user_conf_d, "quit_afterload", "0");
     put(user_conf_d, "numeric_zero", "1");
     put(user_conf_d, "numeric_decimal", "1");
+    put(user_conf_d, "filename_in_status", "0");
     put(user_conf_d, "overlap", "0");
     put(user_conf_d, "truncate", "0");
     put(user_conf_d, "debug", "0");

--- a/src/doc
+++ b/src/doc
@@ -1092,7 +1092,7 @@ Commands for handling cell content:
     Disabled by default, set this variable to enable external functions.  See
     @ext function below.
 
-    'filename_in_status' [default 0]
+    'filename_with_mode' [default 0]
     Set it to '1' to display current filename along with the current mode at
     the right end of the status line.
     Set it to '0', to display the current mode only.

--- a/src/doc
+++ b/src/doc
@@ -1092,6 +1092,11 @@ Commands for handling cell content:
     Disabled by default, set this variable to enable external functions.  See
     @ext function below.
 
+    'filename_in_status' [default 0]
+    Set it to '1' to display current filename along with the current mode at
+    the right end of the status line.
+    Set it to '0', to display the current mode only.
+
     'overlap' [default off]
     If cell content exceedes column width it gets cut off to fit the column
     width.  If overlap is set, the content overflows into the next column.

--- a/src/gram.y
+++ b/src/gram.y
@@ -234,6 +234,7 @@ token S_YANKCOL
 %token K_NONUMERIC_DECIMAL
 %token K_NUMERIC_ZERO
 %token K_NONUMERIC_ZERO
+%token K_FILENAME_IN_STATUS
 %token K_OVERLAP
 %token K_NOOVERLAP
 %token K_TRUNCATE
@@ -1045,10 +1046,15 @@ setlist :
 
 /* things that you can 'set' */
 setitem :
-         K_OVERLAP '=' NUMBER     {  if ($3 == 0) parse_str(user_conf_d, "overlap=0", TRUE);
+         K_FILENAME_IN_STATUS '=' NUMBER {  if ($3 == 0) parse_str(user_conf_d, "filename_in_status=0", TRUE);
+                                     else         parse_str(user_conf_d, "filename_in_status=1", TRUE); }
+    |    K_FILENAME_IN_STATUS     {               parse_str(user_conf_d, "filename_in_status=1", TRUE); }
+
+    |    K_OVERLAP '=' NUMBER     {  if ($3 == 0) parse_str(user_conf_d, "overlap=0", TRUE);
                                      else         parse_str(user_conf_d, "overlap=1", TRUE); }
     |    K_OVERLAP                {               parse_str(user_conf_d, "overlap=1", TRUE); }
     |    K_NOOVERLAP              {               parse_str(user_conf_d, "overlap=0", TRUE); }
+
     |    K_TRUNCATE '=' NUMBER     {  if ($3 == 0) parse_str(user_conf_d, "truncate=0", TRUE);
                                      else         parse_str(user_conf_d, "truncate=1", TRUE); }
     |    K_TRUNCATE               {               parse_str(user_conf_d, "truncate=1", TRUE); }

--- a/src/gram.y
+++ b/src/gram.y
@@ -234,7 +234,8 @@ token S_YANKCOL
 %token K_NONUMERIC_DECIMAL
 %token K_NUMERIC_ZERO
 %token K_NONUMERIC_ZERO
-%token K_FILENAME_IN_STATUS
+%token K_FILENAME_WITH_MODE
+%token K_NOFILENAME_WITH_MODE
 %token K_OVERLAP
 %token K_NOOVERLAP
 %token K_TRUNCATE
@@ -1046,9 +1047,10 @@ setlist :
 
 /* things that you can 'set' */
 setitem :
-         K_FILENAME_IN_STATUS '=' NUMBER {  if ($3 == 0) parse_str(user_conf_d, "filename_in_status=0", TRUE);
-                                     else         parse_str(user_conf_d, "filename_in_status=1", TRUE); }
-    |    K_FILENAME_IN_STATUS     {               parse_str(user_conf_d, "filename_in_status=1", TRUE); }
+         K_FILENAME_WITH_MODE '=' NUMBER {  if ($3 == 0) parse_str(user_conf_d, "filename_with_mode=0", TRUE);
+                                     else         parse_str(user_conf_d, "filename_with_mode=1", TRUE); }
+    |    K_FILENAME_WITH_MODE     {               parse_str(user_conf_d, "filename_with_mode=1", TRUE); }
+    |    K_NOFILENAME_WITH_MODE   {               parse_str(user_conf_d, "filename_with_mode=0", TRUE); }
 
     |    K_OVERLAP '=' NUMBER     {  if ($3 == 0) parse_str(user_conf_d, "overlap=0", TRUE);
                                      else         parse_str(user_conf_d, "overlap=1", TRUE); }

--- a/src/tui.c
+++ b/src/tui.c
@@ -572,7 +572,8 @@ void ui_print_mode() {
     ui_set_ucolor(input_win, &ucolors[MODE]);
     #endif
 
-    if (curfile[0]) {
+    strm[0] = '\0';
+    if (atoi(get_conf_value("filename_in_status")) && curfile[0]) {
         sprintf(strm, "%s ", curfile);
     }
 

--- a/src/tui.c
+++ b/src/tui.c
@@ -573,7 +573,7 @@ void ui_print_mode() {
     #endif
 
     strm[0] = '\0';
-    if (atoi(get_conf_value("filename_in_status")) && curfile[0]) {
+    if (atoi(get_conf_value("filename_with_mode")) && curfile[0]) {
         sprintf(strm, "%s ", curfile);
     }
 

--- a/src/tui.c
+++ b/src/tui.c
@@ -566,11 +566,15 @@ void ui_clr_header(int i) {
 
 void ui_print_mode() {
     unsigned int row = 0; // Print mode in first row
-    char strm[22] = "";
+    char strm[PATHLEN+22] = "";
 
     #ifdef USECOLORS
     ui_set_ucolor(input_win, &ucolors[MODE]);
     #endif
+
+    if (curfile[0]) {
+        sprintf(strm, "%s ", curfile);
+    }
 
     if (curmode == NORMAL_MODE) {
         strcat(strm, " -- NORMAL --");


### PR DESCRIPTION
## Synopsis
Display current file name along with the normal/edit mode currently displayed at top right.

## Rationale/use cases
When multiple spreadsheets are simultaneously being worked on in different windows, it can become hard to tell which is which. Often, I keep a `before` version open in a separate window for reference, and don't want to change that version inadvertently. The mistakes can be reverted of course, and tracked say with _git_, but this goes to simple efficiency and usability.

## How tested
Symlink a test spreadsheet say to `very_very_very_very_long_long_long_name_name_name.sc`, open it with `sc-im` in a very small terminal window. No crashes, filename is displayed, gets overwritten white editing a cell content, but comes right back. 