### PR TITLE
Fix issues when writing colour information to a file

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -385,10 +385,11 @@ void write_fd(register FILE *f, int r0, int c0, int rn, int cn) {
                 // Write ucolors
                 if ((*pp)->ucolor != NULL) {
 
-                    char strcolor[BUFFERSIZE];
+                    char strcolorbuf[BUFFERSIZE];
+                    char * strcolor = strcolorbuf;
                     strcolor[0] = 0;
+                    strcolor[1] = 0;
 
-                    char * gap_to_previous = "";
                     // decompile int value of color to its string description
                     if ((*pp)->ucolor->fg != NONE_COLOR && (*pp)->ucolor->fg != DEFAULT_COLOR) {
                         linelim=0;
@@ -396,9 +397,8 @@ void write_fd(register FILE *f, int r0, int c0, int rn, int cn) {
                         decompile(e, 0);
                         uppercase(line);
                         del_char(line, 0);
-                        sprintf(strcolor, "fg=%.*s", BUFFERSIZE-4, &line[0]);
+                        sprintf(strcolor, " fg=%.*s", BUFFERSIZE-5, &line[0]);
                         free(e);
-                        gap_to_previous = " ";
                     }
                     if ((*pp)->ucolor->bg != NONE_COLOR && (*pp)->ucolor->bg != DEFAULT_COLOR) {
                         linelim=0;
@@ -406,17 +406,19 @@ void write_fd(register FILE *f, int r0, int c0, int rn, int cn) {
                         decompile(e, 0);
                         uppercase(line);
                         del_char(line, 0);
-                        sprintf(strcolor + strlen(strcolor), "%sbg=%s", gap_to_previous, &line[0]);
+                        sprintf(strcolor + strlen(strcolor), " bg=%s", &line[0]);
                         free(e);
-                        gap_to_previous = " ";
                     }
 
-                    if ((*pp)->ucolor->bold)      sprintf(strcolor + strlen(strcolor), "%sbold=1", gap_to_previous);
-                    if ((*pp)->ucolor->dim)       sprintf(strcolor + strlen(strcolor), "%sdim=1", gap_to_previous);
-                    if ((*pp)->ucolor->reverse)   sprintf(strcolor + strlen(strcolor), "%sreverse=1", gap_to_previous);
-                    if ((*pp)->ucolor->standout)  sprintf(strcolor + strlen(strcolor), "%sstandout=1", gap_to_previous);
-                    if ((*pp)->ucolor->underline) sprintf(strcolor + strlen(strcolor), "%sunderline=1", gap_to_previous);
-                    if ((*pp)->ucolor->blink)     sprintf(strcolor + strlen(strcolor), "%sblink=1", gap_to_previous);
+                    if ((*pp)->ucolor->bold)      sprintf(strcolor + strlen(strcolor), " bold=1");
+                    if ((*pp)->ucolor->dim)       sprintf(strcolor + strlen(strcolor), " dim=1");
+                    if ((*pp)->ucolor->reverse)   sprintf(strcolor + strlen(strcolor), " reverse=1");
+                    if ((*pp)->ucolor->standout)  sprintf(strcolor + strlen(strcolor), " standout=1");
+                    if ((*pp)->ucolor->underline) sprintf(strcolor + strlen(strcolor), " underline=1");
+                    if ((*pp)->ucolor->blink)     sprintf(strcolor + strlen(strcolor), " blink=1");
+
+                    // Remove the leading space
+                    strcolor++;
 
                     // previous implementation
                     //(void) fprintf(f, "cellcolor %s%d \"%s\"\n", coltoa((*pp)->col), (*pp)->row, strcolor);

--- a/src/file.c
+++ b/src/file.c
@@ -431,7 +431,7 @@ void write_fd(register FILE *f, int r0, int c0, int rn, int cn) {
                     if ( c > 0 && *ATBL(tbl, r, c-1) != NULL)
                          a = (*ATBL(tbl, r, c-1))->ucolor;
 
-                    if ( (u != NULL) && (c <= maxcol) && ( c == 0 || ( a == NULL ) || ( a != NULL && ! same_ucolor( a, u ) ))) {
+                    if ( *strcolor != '\0' && (u != NULL) && (c <= maxcol) && ( c == 0 || ( a == NULL ) || ( a != NULL && ! same_ucolor( a, u ) ))) {
                         while (c_aux <= maxcol && *ATBL(tbl, r, c_aux) != NULL && same_ucolor( (*ATBL(tbl, r, c_aux))->ucolor, (*pp)->ucolor ))
                             c_aux++;
                         fprintf(f, "cellcolor %s%d", coltoa((*pp)->col), (*pp)->row);

--- a/src/file.c
+++ b/src/file.c
@@ -391,7 +391,7 @@ void write_fd(register FILE *f, int r0, int c0, int rn, int cn) {
                     strcolor[1] = 0;
 
                     // decompile int value of color to its string description
-                    if ((*pp)->ucolor->fg != NONE_COLOR && (*pp)->ucolor->fg != DEFAULT_COLOR) {
+                    if ((*pp)->ucolor->fg != NONE_COLOR) {
                         linelim=0;
                         struct enode * e = new((*pp)->ucolor->fg, (struct enode *)0, (struct enode *)0);
                         decompile(e, 0);
@@ -400,7 +400,7 @@ void write_fd(register FILE *f, int r0, int c0, int rn, int cn) {
                         sprintf(strcolor, " fg=%.*s", BUFFERSIZE-5, &line[0]);
                         free(e);
                     }
-                    if ((*pp)->ucolor->bg != NONE_COLOR && (*pp)->ucolor->bg != DEFAULT_COLOR) {
+                    if ((*pp)->ucolor->bg != NONE_COLOR) {
                         linelim=0;
                         struct enode * e = new((*pp)->ucolor->bg, (struct enode *)0, (struct enode *)0);
                         decompile(e, 0);

--- a/src/interp.c
+++ b/src/interp.c
@@ -3041,6 +3041,10 @@ void decompile(register struct enode *e, int priority) {
             for (s = "@white"; (line[linelim++] = *s++); );
             linelim--;
             break;
+    case DEFAULT_COLOR:
+            for (s = "@default_color"; (line[linelim++] = *s++); );
+            linelim--;
+            break;
     default:
             decompile(e->e.o.left, mypriority);
             line[linelim++] = e->op;


### PR DESCRIPTION
This PR fixes three issues with writing colours to files, the first two of which were introduced in 1dcf37b1.

First, a color with no `bg` or `fg` but multiple modifiers would be saved as e.g. `bold=1underline=1`.

Second, if `fg` or `bg` were `DEFAULT_COLOR`, this would never be saved because 1dcf37b1 treated `DEFAULT_COLOR` and `NONE_COLOR` as the same. I don't understand why there needs to be a difference, but the rest of the program clearly treats them as different. The fix for this modifies the `decompile` function; I am not sure if this goes against the idea of the function somehow, but it seems to work.

Third, empty cellcolor strings would sometimes be saved (such as `cellcolor A1:A2 ""`).