### PR TITLE
Add full XDG Base Specification compliance

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,10 +11,10 @@ LIBDIR  = $(prefix)/share/doc/$(name)
 # This is where the man page goes.
 MANDIR  = $(prefix)/share/man/man1
 
-# This is where the history file go
+# History directory, relative to $HOME
 HISTORY_DIR= .cache
 HISTORY_FILE=sc-iminfo
-# This is where the config file go
+# Configuration directory, relative to $HOME
 CONFIG_DIR= .config/sc-im
 CONFIG_FILE=scimrc
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,8 +13,10 @@ MANDIR  = $(prefix)/share/man/man1
 
 # This is where the history file go
 HISTORY_DIR= .cache
+HISTORY_FILE=sc-iminfo
 # This is where the config file go
 CONFIG_DIR= .config/sc-im
+CONFIG_FILE=scimrc
 
 # Change these to your liking or use `make CC=gcc` etc
 #CC   = cc
@@ -37,9 +39,9 @@ CFLAGS += -DDFLT_EDITOR=\"vim\"
 # Comment out to disable color support
 CFLAGS += -DUSECOLORS
 # Command history file, relative to HISTORY_DIR directory. Comment out to disable commandline history
-CFLAGS += -DHISTORY_FILE=\"sc-iminfo\" -DHISTORY_DIR=\"$(HISTORY_DIR)\"
+CFLAGS += -DHISTORY_FILE=\"$(HISTORY_FILE)\" -DHISTORY_DIR=\"$(HISTORY_DIR)\"
 # Configuration file, relative to CONFIG_DIR directory
-CFLAGS += -DCONFIG_FILE=\"scimrc\" -DCONFIG_DIR=\"$(CONFIG_DIR)\"
+CFLAGS += -DCONFIG_FILE=\"$(CONFIG_FILE)\" -DCONFIG_DIR=\"$(CONFIG_DIR)\"
 # Input mode history. Same as previous, but for insert mode commands
 CFLAGS += -DINS_HISTORY_FILE=\"sc-iminfo\"
 # Comment out to disable undo/redo support

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ MANDIR  = $(prefix)/share/man/man1
 # This is where the history file go
 HISTORY_DIR= .cache
 # This is where the config file go
-CONFIG_DIR= .config
+CONFIG_DIR= .config/sc-im
 
 # Change these to your liking or use `make CC=gcc` etc
 #CC   = cc

--- a/src/file.c
+++ b/src/file.c
@@ -1528,9 +1528,7 @@ int plugin_exists(char * name, int len, char * path) {
         }
     }
     if ((HomeDir = getenv("HOME"))) {
-        strcpy((char *) path, HomeDir);
-        strcat((char *) path, "/.scim/");
-        strncat((char *) path, name, len);
+        sprintf((char *) path, "%s/%s/%s/%s", HomeDir, CONFIG_DIR, "sc-im", name);
         if ((fp = fopen((char *) path, "r"))) {
             fclose(fp);
             return 1;

--- a/src/file.c
+++ b/src/file.c
@@ -135,7 +135,15 @@ void loadrc(void) {
     char rcpath[PATHLEN];
     char * home;
 
-    if ((home = getenv("HOME"))) {
+    if ((home = getenv("XDG_CONFIG_HOME"))) {
+        char config_dir[PATHLEN];
+        sprintf(config_dir, "%s/sc-im", home);
+        mkdir(config_dir,0777);
+        sprintf(rcpath, "%s/%s", config_dir, CONFIG_FILE);
+        (void) readfile(rcpath, 0);
+    }
+    /* Default to compile time if XDG_CONFIG_HOME not found */
+    else if ((home = getenv("HOME"))) {
         char config_dir[PATHLEN];
         sprintf(config_dir, "%s/%s", home,CONFIG_DIR);
         mkdir(config_dir,0777);
@@ -1527,8 +1535,25 @@ int plugin_exists(char * name, int len, char * path) {
             return 1;
         }
     }
+    /* Check XDG_CONFIG_HOME */
+    if ((HomeDir = getenv("XDG_CONFIG_HOME"))) {
+        sprintf((char *) path, "%s/sc-im/%s", HomeDir, name);
+        if ((fp = fopen((char *) path, "r"))) {
+            fclose(fp);
+            return 1;
+        }
+    }
+    /* Check compile time path (default ~/.config/sc-im) */
     if ((HomeDir = getenv("HOME"))) {
-        sprintf((char *) path, "%s/%s/%s/%s", HomeDir, CONFIG_DIR, "sc-im", name);
+        sprintf((char *) path, "%s/%s/%s", HomeDir, CONFIG_DIR, name);
+        if ((fp = fopen((char *) path, "r"))) {
+            fclose(fp);
+            return 1;
+        }
+    }
+    /* LEGACY PATH */
+    if ((HomeDir = getenv("HOME"))) {
+        sprintf((char *) path, "%s/.scim/%s", HomeDir, name);
         if ((fp = fopen((char *) path, "r"))) {
             fclose(fp);
             return 1;

--- a/src/history.c
+++ b/src/history.c
@@ -153,11 +153,16 @@ void load_history(struct history * h, wchar_t mode) {
     char infofile[PATHLEN];
     wchar_t linea[FBUFLEN];
     int c;
-    char * home;
+    char * home, *xdghome;
     FILE * f;
 
     if ((home = getenv("HOME"))) {
-        sprintf(infofile, "%s/%s/%s", home,HISTORY_DIR,HISTORY_FILE);
+        if ((xdghome = getenv("XDG_CACHE_HOME"))) {
+            sprintf(infofile, "%s/%s", xdghome,HISTORY_FILE);
+        } else {
+            /* Default to compile time HISTORY_DIR if XDG_CACHE_HOME isn't set. */
+            sprintf(infofile, "%s/%s/%s", home,HISTORY_DIR,HISTORY_FILE);
+        }
         if ((c = open(infofile, O_RDONLY)) > -1) {
             close(c);
             f = fopen(infofile, "r");
@@ -189,15 +194,21 @@ void load_history(struct history * h, wchar_t mode) {
 
 int save_history(struct history * h, char * mode) {
     char infofile [PATHLEN];
-    char * home;
+    char * home, * xdghome;
     FILE * f;
     int i;
     struct hlist * nl = h->list;
     if ((home = getenv("HOME"))) {
         char history_dir[PATHLEN];
-        sprintf(history_dir, "%s/%s", home,HISTORY_DIR);
-        mkdir(history_dir,0777);
-        sprintf(infofile, "%s/%s/%s", home,HISTORY_DIR,HISTORY_FILE);
+        if ((xdghome = getenv("XDG_CACHE_HOME"))) {
+            sprintf(history_dir, "%s/%s", home,xdghome);
+            mkdir(history_dir,0777);
+            sprintf(infofile, "%s/%s", history_dir,HISTORY_FILE);
+        } else {
+            sprintf(history_dir, "%s/%s", home,HISTORY_DIR);
+            mkdir(history_dir,0777);
+            sprintf(infofile, "%s/%s/%s", home,HISTORY_DIR,HISTORY_FILE);
+        }
         f = fopen(infofile, mode);
         if (f == NULL) return 0;
         // Go to the end


### PR DESCRIPTION
This closes #358.

This pull request changes default configuration and history file finding behaviour. In short:

 * **BREAKING** - In the Makefile, `CONFIG_DIR` is set to `~/.config/sc-im/` by default. This means that `scimrc` must instead be placed in `~/.config/sc-im/scimrc` by default.
 * The hardcoded path in `plugin_exists` has been removed, and sc-im will search for plugin files in `CONFIG_DIR` or in `$XDG_CONFIG_HOME/sc-im`. It should still search the old hardcoded path `~/.scim` for compatibility reasons, but this should probably be deprecated.
 * If `$XDG_CONFIG_HOME` or `$XDG_CACHE_HOME` are set, sc-im will ignore the `CONFIG_DIR` and `HISTORY_DIR` set at compile time. `CONFIG_DIR` effectively becomes `$XDG_CONFIG_HOME/sc-im`, while `HISTORY_DIR` has no change from default behaviour.