### PR TITLE
move (invisible) cursor to the active grid cell

### DIFF
--- a/src/help.c
+++ b/src/help.c
@@ -407,6 +407,7 @@ int show_lines() {
         wclrtobot(main_win);
     }
 
+    wmove(main_win, 0, 0);
     (void) wrefresh(main_win);
     return wgetch(input_win);
 }


### PR DESCRIPTION
This is especially useful for blind people using braille displays.

A braille display is a device with mechanical dots representing the
content of the screen in braille with the aid of a software package
such as BRLTTY. Those displays are made of a single line with a variable
number of rows depending on the model, usually 40 or 80. This is
effectively a 1x40 window view of the screen.

By default, the braille window moves with the position of the screen
cursor. It doesn't track attributes such as reverse color as this is
too unreliable. Finding the actual active cell manually is a daunting
task.

This patch makes sc-im locate the cursor in the active cell when
navigating around so the braille window can automatically be located
on the active cell, or on the input field when active, or on the last
status message, hugely improving the user experience.
