### PR TITLE
fix column header display

### DIFF
--- a/src/tui.c
+++ b/src/tui.c
@@ -718,7 +718,6 @@ void ui_show_sc_col_headings(WINDOW * win, int mxcol) {
          i > freeze_ranges->br->col && i <= freeze_ranges->br->col + center_hidden_cols) || (
          i < freeze_ranges->tl->col && i >= freeze_ranges->tl->col - center_hidden_cols))) continue;
 
-        int k = fwidth[i] / 2;
         srange * s = get_selected_range();
         if ( (s != NULL && i >= s->tlcol && i <= s->brcol) || i == curcol ) {
             #ifdef USECOLORS
@@ -727,7 +726,9 @@ void ui_show_sc_col_headings(WINDOW * win, int mxcol) {
             wattron(win, A_REVERSE);
             #endif
         }
-        (void) mvwprintw(win, 0, col, "%*s%-*s", k-1, " ", fwidth[i] - k + 1, coltoa(i));
+
+        int k = (fwidth[i] - 1) / 2;
+        mvwprintw(win, 0, col, "%*s%-*s", k, "", fwidth[i] - k, coltoa(i));
 
         /* We also colorize the columns with alternate color
         #ifdef USECOLORS


### PR DESCRIPTION
The centering of the column header is done by padding with spaces on the
left. This padding is at least one space. This breaks the header display
when a column width is set to 2 and the header is a double-letter as the
second letter overflows the field and gets overwritten.

Rework the padding computation so that double-letter headings are always
properly centered, including in the extreme case with a width of 2 where
no padding at all should be applied.

This also properly aligns single-letter headers with centered single-letter
cell content when the field width is odd.
