### PR TITLE
fix dictionary string parser

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -107,12 +107,7 @@ const char default_config[] =
 // argument rather than using user_conf_d directly.
 
 void store_default_config_values() {
-    const char *line = default_config;
-
-    do {
-        parse_str(user_conf_d, line, 0);
-	line = strchr(line, '\n');
-    } while(line && *++line != 0);
+    parse_str(user_conf_d, default_config, 0);
 	
     // Calculate GMT offset (not on Solaris, doesn't have tm_gmtoff)
     #if defined(USELOCALE) && !defined(__sun)

--- a/src/main.c
+++ b/src/main.c
@@ -551,15 +551,7 @@ void read_argv(int argc, char ** argv) {
     int i;
     for (i = 1; i < argc; i++) {
         if ( ! strncmp(argv[i], "--", 2) ) {       // it was passed a parameter
-            char *dup = strdup(argv[i]);
-            char *rest = dup;
-            char *name = strsep(&rest, "=");
-            if (rest) {
-                put(user_conf_d, &name[2], rest);  // --parameter=value
-            } else {
-                put(user_conf_d, &name[2], "1");   // --parameter
-            }
-            free(dup);
+            parse_str(user_conf_d, argv[i] + 2, 0);
         } else {                                   // it was passed a file
             strncpy(loadingfile, argv[i], PATHLEN-1);
         }

--- a/src/utils/dictionary.h
+++ b/src/utils/dictionary.h
@@ -60,5 +60,5 @@ void destroy_dictionary(struct dictionary * d);
 char * get(struct dictionary * d, const char * key);
 int get_int(struct dictionary * d, const char * key); 
 //char * get_key_name(struct dictionary * d, const char * value);
-void parse_str(struct dictionary * d, const char * str, int no_blanks);
+void parse_str(struct dictionary * d, const char * str, int split_on_blanks);
 int get_dict_buffer_size(struct dictionary * d); 


### PR DESCRIPTION
I didn't notice that multiple key=value pairs were possible in a single
string. Here's a new implementation that does it, with the ability to
parse the whole default_config string as well as command line args.
