### PR TITLE
Enabled higher versisons of lua by making compile independent of user…

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -135,15 +135,19 @@ ifneq (, $(shell which pkg-config))
   endif
 
   # NOTE: lua support
-  ifneq ($(shell pkg-config --exists lua51 || echo 'no'),no)
-    CFLAGS += -DXLUA $(shell pkg-config --cflags lua51)
-    LDLIBS += $(shell pkg-config --libs lua51) -Wl,--export-dynamic
-  else ifneq ($(shell pkg-config --exists lua-5.1 || echo 'no'),no) # FreeBSD
-    CFLAGS += -DXLUA $(shell pkg-config --cflags lua-5.1)
+  ifneq ($(shell pkg-config --exists lua || echo 'no'),no) # Check for user's default lua
+    CFLAGS += -DXLUA $(shell pkg-config --cflags lua)
     ifneq ($(shell uname -s),Darwin)
-      LDLIBS += $(shell pkg-config --libs lua-5.1) -Wl,--export-dynamic
+      LDLIBS += $(shell pkg-config --libs lua) -Wl,--export-dynamic
     else
-      LDLIBS += $(shell pkg-config --libs lua-5.1) -rdynamic
+      LDLIBS += $(shell pkg-config --libs lua) -rdynamic
+    endif
+  else ifneq ($(shell pkg-config --exists luajit || echo 'no'),no) # If not found, check for luajit
+    CFLAGS += -DXLUA $(shell pkg-config --cflags luajit)
+    ifneq ($(shell uname -s),Darwin)
+      LDLIBS += $(shell pkg-config --libs luajit) -Wl,--export-dynamic
+    else
+      LDLIBS += $(shell pkg-config --libs luajit) -rdynamic
     endif
   endif
 else ifeq ($(shell uname -s),Darwin)

--- a/src/lua.c
+++ b/src/lua.c
@@ -295,7 +295,7 @@ LC_NUMBER2(curcol,curcol)
 LC_NUMBER2(maxcols,maxcols)
 LC_NUMBER2(maxrows,maxrows)
 
-static const luaL_reg sclib[] = {
+static const luaL_Reg sclib[] = {
     { "lgetnum", l_getnum },
     { "lsetnum", l_setnum },
     { "lsetform", l_setform },
@@ -311,6 +311,13 @@ static const luaL_reg sclib[] = {
     { "sc", l_sc},
     {NULL,NULL}
 };
+
+static int registerLuaFuncs(lua_State *L) {
+#if LUA_VERSION_NUM >= 502
+    luaL_newlib(L, sclib);                          /* Load SC specific LUA commands after init.lua exec*/
+#endif
+    return 1;
+}
 
 /**
  * \brief TODO Document doLuainit()
@@ -334,7 +341,13 @@ void doLuainit() {
         if (lua_pcall(L, 0, 0, 0))                  /* PRIMING RUN. FORGET THIS AND YOU'RE TOAST */
             fprintf(stderr, "\nFATAL ERROR:\n  Couldn't initialized Lua: %s\n\n", lua_tostring(L,-1));
     }
+
+
+#if LUA_VERSION_NUM >= 502
+    luaL_requiref(L, "sc", registerLuaFuncs, 1);    /* sc = require("sc") */
+#else
     luaL_register(L, "sc", sclib);                  /* Load SC specific LUA commands after init.lua exec*/
+#endif
 
     return;
 }


### PR DESCRIPTION
Enabled higher versisons of lua by making compile independent of user's lua version. Now lua version to link to is not hard-coded, so sc-im will link to whatever lua version user has installed as their default lua. If lua is not found, Makefile then checks for luaJIT & links to luaJIT instead. Given lua is checked before luaJIT, newer compiles will always link to latest version of lua user has, this is what most users would care about. For advanced users who care about high-performance of luaJIT & do not mind keeping their code compliant to Lua 5.1 & have both lua+luaJIT installed on their machines, they can comment part of Makefile (or remove lua from pkg-config path) to force sc-im to link to luaJIT.