### PR TITLE
.mkd import, read write mardown, update docs

### DIFF
--- a/examples/markdown/markdown-table-alignment.md
+++ b/examples/markdown/markdown-table-alignment.md
@@ -1,0 +1,6 @@
+| Ingredient |     Amount |       unit |
+|-----------:|-----------:|-----------:|
+|   Sardines |       1.00 |       kilo |
+|    Garlick |       3.00 |       toes |
+|    Parsley |       1.00 |      bunch |
+| White wine |       1.00 |     bottle |

--- a/examples/markdown/markdown-table.md
+++ b/examples/markdown/markdown-table.md
@@ -1,0 +1,6 @@
+| Description | Amount     | Unit       |
+|-------------|------------|------------|
+| Sardines    |       1.00 | kilo       |
+| Garlick     |       3.00 | toes       |
+| Parsley     |       1.00 | bunch      |
+| White wine  |       1.00 | bottle     |

--- a/src/doc
+++ b/src/doc
@@ -403,8 +403,8 @@ Commands for handling cell content:
                  Load {file} into the SC-IM database.
 
                  {file} can be an sc format file (.sc), a comma-separated file
-                 (.csv), a tab-separated file (.tab, .tsv), an xlsx or xls
-                 file.
+                 (.csv), a tab-separated file (.tab, .tsv),a markdown table
+                 file (.md, mkd, .markdown), an xlsx or xls file.
 
                  If loading a csv, tab or tsv file and
                  'import_delimited_as_text' configuration variable is set
@@ -1720,6 +1720,8 @@ Commands for handling cell content:
         .tsv    Tab-separated values
         .tab    Tab-separated values
         .txt    Simple text files
+        .mkd    Markdown file with only table contents
+        .md     Markdown file with only table contents
 
     You can pass files of any of the above formats to SC-IM binary.
     If you pass a .txt or .csv file to SC-IM, it is imported using a comma as

--- a/src/file.h
+++ b/src/file.h
@@ -68,6 +68,7 @@ FILE * openfile(char *fname, int *rpid, int *rfd);
 void closefile(FILE *f, int pid, int rfd);
 void print_options(FILE *f);
 int import_csv(char * fname, char d);
+int import_markdown(char * fname);
 void do_export(int r0, int c0, int rn, int cn);
 void export_delim(char * fname, char coldelim, int r0, int c0, int rn, int cn, int verbose);
 void export_plain(char * fname, int r0, int c0, int rn, int cn);


### PR DESCRIPTION
Refreshed version of an old PR branch. Ready to merge.

## Features
- sc-im can now import .mkd files
- when current file is .mkd is writes to .mkd format
- markdown column alignment is respected.
- doc and help are updated

When this is merged https://github.com/mipmip/vim-scimark should work with the vanilla sc-im

