### PR TITLE
recalculate number of mobile rows if row height changes during display

### DIFF
--- a/src/tui.h
+++ b/src/tui.h
@@ -91,7 +91,7 @@ void ui_start_colors();
 void ui_sc_msg(char * s, int type, ...);
 
 void ui_set_ucolor(WINDOW * w, struct ucolor * uc, int bg_override);
-void ui_show_content(WINDOW * win, int mxrow, int mxcol);
+int ui_show_content(WINDOW * win, int mxrow, int mxcol);
 void ui_show_sc_row_headings(WINDOW * win, int mxrow);
 void ui_show_sc_col_headings(WINDOW * win, int mxcol);
 void ui_add_cell_detail(char * d, struct ent * p1);


### PR DESCRIPTION
The displaying of a row may have its height dynamically adjusted.
When that happens, the number of displayable rows may no longer be
correct, leading to currow being located outside of the screen.

Let's work around this issue by redrawing the screen in that case after
all potentially displayable rows had their height validated.

Fixes #578.
