### PR TITLE
fix label string alignment in man-page

### DIFF
--- a/src/sc-im.1
+++ b/src/sc-im.1
@@ -159,10 +159,10 @@ Jump to a marked cell.
 Enter a numeric constant or expression into the current cell.
 .TP
 .BR <
-Enter a label string into the current cell. Right aligned
+Enter a label string into the current cell. Left aligned
 .TP
 .BR >
-Enter a label string into the current cell. Left aligned
+Enter a label string into the current cell. Right aligned
 .TP
 .BR {
 Left justify the string in the current cell.


### PR DESCRIPTION
Found this small typo while reading the man page. I hope you don't mind the PR.