### PR TITLE
add input_edit_mode setting

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -79,6 +79,7 @@ const char default_config[] =
     "version=0\n"
     "help=0\n"
     "input_bar_bottom=0\n"
+    "input_edit_mode=0\n"
     "underline_grid=0\n"
 
 #ifdef AUTOBACKUP

--- a/src/doc
+++ b/src/doc
@@ -1355,6 +1355,9 @@ Commands for handling cell content:
     'input_bar_bottom' [default off]
     Place the input bar at the bottom of the screen.
 
+    'input_edit_mode' [default off]
+    Always go from input to edit mode when pressing ESC.
+
     'underline_grid' [default off]
     Underline cells to make a nicer grid
 

--- a/src/gram.y
+++ b/src/gram.y
@@ -273,6 +273,7 @@ token S_YANKCOL
 %token K_INPUT_BAR_BOTTOM
 %token K_IGNORE_HIDDEN
 %token K_NOIGNORE_HIDDEN
+%token K_INPUT_EDIT_MODE
 %token K_UNDERLINE_GRID
 %token K_TRUNCATE
 %token K_NOTRUNCATE
@@ -1558,6 +1559,13 @@ setitem :
                                      else         parse_str(user_conf_d, "input_bar_bottom=1", TRUE);
                                                   ui_mv_bottom_bar(); }
     |    K_INPUT_BAR_BOTTOM       {               parse_str(user_conf_d, "input_bar_bottom=1", TRUE);
+                                                  ui_mv_bottom_bar();
+                                  }
+
+    |    K_INPUT_EDIT_MODE '=' NUMBER   {  if ($3 == 0) parse_str(user_conf_d, "input_edit_mode=0", TRUE);
+                                     else         parse_str(user_conf_d, "input_edit_mode=1", TRUE);
+                                                  ui_mv_bottom_bar(); }
+    |    K_INPUT_EDIT_MODE        {               parse_str(user_conf_d, "input_edit_mode=1", TRUE);
                                                   ui_mv_bottom_bar();
                                   }
 

--- a/src/input.c
+++ b/src/input.c
@@ -238,7 +238,10 @@ void break_waitcmd_loop(struct block * buffer) {
     } else if (curmode == VISUAL_MODE) {
         exit_visualmode();
     }
-    if (curmode == INSERT_MODE && lastmode == EDIT_MODE)     {
+    if (
+         curmode == INSERT_MODE &&
+         ( lastmode == EDIT_MODE || get_conf_int("input_edit_mode") )
+       ) {
         if (inputline_pos && wcslen(inputline) >= inputline_pos) {
             real_inputline_pos--;
             int l = wcwidth(inputline[real_inputline_pos]);


### PR DESCRIPTION
This option allows to always go from input to edit mode when pressing ESC.

See #620 