### PR TITLE
Pass cell contents correctly when following links

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -2172,10 +2172,13 @@ int backup_exists(char * file) {
 void openfile_nested(char * file) {
     char * cmd = get_conf_value("default_open_file_under_cursor_cmd");
     if (cmd == NULL || ! strlen(cmd)) return;
-    char syscmd[PATHLEN + strlen(cmd)];
-    sprintf(syscmd, "%s", cmd);
-    sprintf(syscmd + strlen(syscmd), " %s", file);
-    system(syscmd);
+    pid_t pid = fork();
+    if (pid == 0) {
+        execlp(cmd, cmd, file, NULL);
+        exit(EXIT_FAILURE);
+    } else if (pid > 0) {
+        waitpid(pid, NULL, 0);
+    }
 }
 
 


### PR DESCRIPTION
At the moment, following links / opening files from cells with ampersands, spaces, etc. doesn't work as expected for obvious reasons.
e.g. `https://example.com/?a&shutdown now` (less contrived examples do exist).

Thanks.