### PR TITLE
Allow changing default_open_file_under_cursor_cmd at runtime

### DIFF
--- a/src/doc
+++ b/src/doc
@@ -59,7 +59,10 @@ Navigation commands:
      g$          Go to the rightmost column visible on screen.
      gM          Go to the middle column on the screen.
      gf          Open filename or URL in current cell.
-                 Uses helper script 'scopen'.
+                 Uses helper script 'scopen' by default.
+                 A different executable may be used by changing the
+                 'default_open_file_under_cursor_cmd' configuration variable
+                 at runtime, using the :set command.
      H           Go to the top row visible on screen.
      L           Go to the lowest row visible on screen.
      M           Go to the middle row on the screen.
@@ -2162,6 +2165,7 @@ Commands for handling cell content:
     COPY_TO_CLIPBOARD_DELIMITED_TAB
     COPY_TO_CLIPBOARD_DELIMITED_TAB = {NUMBER}
     NOCOPY_TO_CLIPBOARD_DELIMITED_TAB
+    DEFAULT_OPEN_FILE_UNDER_CURSOR_CMD = {strarg}
     NEWLINE_ACTION = {NUMBER}
     TM_GMTOFF
     TM_GMTOFF = {num}

--- a/src/gram.y
+++ b/src/gram.y
@@ -288,6 +288,7 @@ token S_YANKCOL
 %token K_DEFAULT_PASTE_FROM_CLIPBOARD_CMD
 %token K_COPY_TO_CLIPBOARD_DELIMITED_TAB
 %token K_NOCOPY_TO_CLIPBOARD_DELIMITED_TAB
+%token K_DEFAULT_OPEN_FILE_UNDER_CURSOR_CMD
 %token K_IGNORECASE
 %token K_NOIGNORECASE
 %token K_TM_GMTOFF
@@ -1683,6 +1684,14 @@ setitem :
                                   {  if ($3 == 0) parse_str(user_conf_d, "copy_to_clipboard_delimited_tab=0", TRUE);
                                      else         parse_str(user_conf_d, "copy_to_clipboard_delimited_tab=1", TRUE); }
     |    K_NOCOPY_TO_CLIPBOARD_DELIMITED_TAB {    parse_str(user_conf_d, "copy_to_clipboard_delimited_tab=0", TRUE); }
+
+    |    K_DEFAULT_OPEN_FILE_UNDER_CURSOR_CMD '=' strarg {
+                                  char cmd[MAXCMD];
+                                  char * s = (char *) $3;
+                                  sprintf(cmd, "default_open_file_under_cursor_cmd=%s", s);
+                                  parse_str(user_conf_d, cmd, FALSE);
+                                  scxfree(s);
+                                  }
 
     |    K_NEWLINE_ACTION '=' NUMBER {
                                      if ($3 == 0) parse_str(user_conf_d, "newline_action=0", TRUE); }


### PR DESCRIPTION
Not sure if this was a deliberate omission or just an oversight. Either way I think it's useful to be able to change this without recompiling (e.g. desktop users might prefer xdg-open).

I've copied how this works from default_copy_to_clipboard_cmd, which seems to work fine.