### PR TITLE
Fix UB when parsing

### DIFF
--- a/src/gram.y
+++ b/src/gram.y
@@ -1239,12 +1239,15 @@ command:
     |    // nothing
     |    error   {
                      sc_error("syntax error: %s", line);
-                     line[0]='\0';
+                     YYABORT;
+
                      //linelim = 0;
                      //yyparse();
-                     linelim = -1;
-                     yyclearin;
-                     yyerrok;
+
+                     //line[0]='\0';
+                     //linelim = -1;
+                     //yyclearin;
+                     //yyerrok;
                  };
 
 term:   var                       {

--- a/src/lex.c
+++ b/src/lex.c
@@ -160,9 +160,9 @@ int yylex() {
                 for (tblp = linelim ? experres : statres; tblp->key; tblp++) {
                     if (((tblp->key[0]^tokenst[0])&0137)==0) {
                         int i = 1;
-                        while (i<tokenl && ((tokenst[i]^tblp->key[i])&0137)==0)
+                        while (tblp->key[i] && i<tokenl && ((tokenst[i]^tblp->key[i])&0137)==0)
                             i++;
-                        if (i >= tokenl) {
+                        if (i >= tokenl && tblp->key[i] == '\0') {
                             ret = tblp->val;
                             colstate = (ret <= S_FORMAT);
                             if (isgoto) {

--- a/src/lex.c
+++ b/src/lex.c
@@ -157,23 +157,23 @@ int yylex() {
             ret = WORD;
             if (!linelim || isfunc) {
                 if (isfunc) isfunc--;
-                for (tblp = linelim ? experres : statres; tblp->key; tblp++)
-                    if (((tblp->key[0]^tokenst[0])&0137)==0
-                        && tblp->key[tokenl]==0) {
-                    int i = 1;
-                    while (i<tokenl && ((tokenst[i]^tblp->key[i])&0137)==0)
-                        i++;
-                    if (i >= tokenl) {
-                        ret = tblp->val;
-                        colstate = (ret <= S_FORMAT);
-                        if (isgoto) {
-                            isfunc = isgoto = 0;
-                            if (ret != K_ERROR && ret != K_INVALID)
-                                ret = WORD;
+                for (tblp = linelim ? experres : statres; tblp->key; tblp++) {
+                    if (((tblp->key[0]^tokenst[0])&0137)==0) {
+                        int i = 1;
+                        while (i<tokenl && ((tokenst[i]^tblp->key[i])&0137)==0)
+                            i++;
+                        if (i >= tokenl) {
+                            ret = tblp->val;
+                            colstate = (ret <= S_FORMAT);
+                            if (isgoto) {
+                                isfunc = isgoto = 0;
+                                if (ret != K_ERROR && ret != K_INVALID)
+                                    ret = WORD;
                             }
                             break;
                         }
                     }
+                }
             }
 
             if (ret == WORD) {


### PR DESCRIPTION
Closes #788. Also fixes potential buffer overruns in `yylex`.

Currently, when the lexer finds a `WORD` it loops through the keys in `statres.h` or `experres.h` and looks for a match. It does this by comparing the first character of the token with each key case insensitively, and if that succeeds, checks if the character in the key at `tokenl` is a null byte. If the key string begins with the same character as the token string, and is shorter than the token string, then there is a buffer overflow on this check.