### PR TITLE
Save Sheet name in xlsx file

### DIFF
--- a/src/formats/xlsx.c
+++ b/src/formats/xlsx.c
@@ -573,7 +573,7 @@ int export_xlsx(char * filename) {
     struct sheet * sh = roman->first_sh;
     while (sh != NULL) {
 
-        lxw_worksheet * worksheet = workbook_add_worksheet(workbook, NULL);
+        lxw_worksheet * worksheet = workbook_add_worksheet(workbook, sh->name);
         int bkp_currow = sh->currow;
         sh->currow = 0;
         insert_row(sh, 0); //add a row so that scim formulas apply to excel


### PR DESCRIPTION
When saving a file in xlsx format, the custom sheet names are not saved in the workbook and only the default names are stored.
This PR aims to solve this issue, by making the sheet name savable. 