### PR TITLE
Include string.h where needed

### DIFF
--- a/src/actions/hide_show.c
+++ b/src/actions/hide_show.c
@@ -43,6 +43,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "../sc.h"
 #include "../macros.h"

--- a/src/actions/subtotal.c
+++ b/src/actions/subtotal.c
@@ -43,6 +43,7 @@
  */
 
 #include <wchar.h>
+#include <string.h>
 #include "../sc.h"
 #include "../macros.h"
 #include "../cmds/cmds.h"
@@ -51,7 +52,6 @@
 
 /*
 #include <sys/types.h>
-#include <string.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>

--- a/src/cmds/cmds.c
+++ b/src/cmds/cmds.c
@@ -43,6 +43,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include <ctype.h>   // for isdigit
 #include <wchar.h>
 #include <wctype.h>

--- a/src/cmds/cmds_normal.c
+++ b/src/cmds/cmds_normal.c
@@ -44,6 +44,7 @@
 
 #include <ctype.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "cmds.h"
 #include "cmds_edit.h"

--- a/src/file.c
+++ b/src/file.c
@@ -51,6 +51,7 @@
 #include <signal.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <wchar.h>
 #include <sys/wait.h>

--- a/src/formats/ods.c
+++ b/src/formats/ods.c
@@ -47,6 +47,7 @@
  */
 
 #ifdef ODS
+#include <string.h>
 #include <errno.h>
 #include <zip.h>
 #include <libxml/parser.h>

--- a/src/gram.y
+++ b/src/gram.y
@@ -1,5 +1,6 @@
 %{
 #include <stdlib.h>
+#include <string.h>
 
 #include "sc.h"
 #include "cmds/cmds.h"

--- a/src/graph.c
+++ b/src/graph.c
@@ -59,6 +59,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <setjmp.h>
 #include <math.h>
 

--- a/src/lua.c
+++ b/src/lua.c
@@ -61,6 +61,7 @@
 #include <ctype.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <string.h>
 #include <wchar.h>
 
 #include "sc.h"

--- a/src/sheet.c
+++ b/src/sheet.c
@@ -44,6 +44,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include "sheet.h"
 #include "file.h"
 #include "yank.h"


### PR DESCRIPTION
This came up [before](https://github.com/andmarti1424/sc-im/pull/369) and fizzled out but unfortunately

> I believe its included where needed.

it is not:

    $ uname -a
    SunOS hipster 5.11 illumos-9ffcdb10b6 i86pc i386 i86pc
    
    $ gcc --version
    gcc (OpenIndiana 10.5.0-oi-0) 10.5.0
    ...
    
    $ gmake 2>&1 | grep "implicit declaration"
    file.c:199:10: warning: implicit declaration of function 'strcasecmp' [-Wimplicit-function-declaration]
    file.c:249:16: warning: implicit declaration of function 'strlen' [-Wimplicit-function-declaration]
    file.c:249:16: warning: incompatible implicit declaration of built-in function 'strlen'
    file.c:266:28: warning: incompatible implicit declaration of built-in function 'strlen'
    file.c:271:31: warning: incompatible implicit declaration of built-in function 'strlen'
    file.c:283:9: warning: implicit declaration of function 'strcpy' [-Wimplicit-function-declaration]
    file.c:283:9: warning: incompatible implicit declaration of built-in function 'strcpy'
    file.c:288:27: warning: incompatible implicit declaration of built-in function 'strlen'
    file.c:291:16: warning: incompatible implicit declaration of built-in function 'strlen'
    file.c:358:12: warning: incompatible implicit declaration of built-in function 'strcpy'
    file.c:529:52: warning: incompatible implicit declaration of built-in function 'strlen'
    file.c:532:52: warning: incompatible implicit declaration of built-in function 'strlen'
    file.c:536:74: warning: incompatible implicit declaration of built-in function 'strlen'
    file.c:537:74: warning: incompatible implicit declaration of built-in function 'strlen'
    file.c:538:74: warning: incompatible implicit declaration of built-in function 'strlen'
    file.c:539:74: warning: incompatible implicit declaration of built-in function 'strlen'
    file.c:540:74: warning: incompatible implicit declaration of built-in function 'strlen'
    file.c:541:74: warning: incompatible implicit declaration of built-in function 'strlen'
    ...

Not including string.h in these files may happen to work on one platform or another because other headers happen to include it, but that shouldn't be relied on - if functions from a certain header are used, the header should be included.