### PR TITLE
Address 'misleading indentation' warning

### DIFF
--- a/src/lex.c
+++ b/src/lex.c
@@ -267,11 +267,11 @@ int yylex() {
                 } else if (*p == 'e' || *p == 'E') {
                     while (isdigit(*++p))
                         ;
-                        if (isalpha(*p) || *p == '_') {
-                            linelim = p - line;
-                            return (yylex());
-                        } else
-                            ret = FNUMBER;
+                    if (isalpha(*p) || *p == '_') {
+                        linelim = p - line;
+                        return (yylex());
+                    } else
+                        ret = FNUMBER;
                 } else if (isalpha(*p) || *p == '_') {
                     linelim = p - line;
                     return (yylex());


### PR DESCRIPTION
    $ uname -a
    OpenBSD openbsd.joosts-fw13 7.3 GENERIC.MP#1125 amd64
    
    $ cc --version
    OpenBSD clang version 13.0.0
    Target: amd64-unknown-openbsd7.3
    Thread model: posix
    InstalledDir: /usr/bin
    
    lex.c:270:25: warning: misleading indentation; statement is not part of the previous 'while' [-Wmisleading-indentation]
                            if (isalpha(*p) || *p == '_') {
                            ^
    lex.c:268:21: note: previous statement is here
                        while (isdigit(*++p))
                        ^