### PR TITLE
Add Makefile flags to ease building on Cygwin

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,12 @@
 # Specify the name of the resulting executable file
 name = sc-im
 
+# Specify some Options
+
+## Build in cygwin environment with previously compiled libxlsxwriter
+O_CYGWIN := 0 		
+O_LIBXLSXWRITER_ROOT := "../../libxlsxwriter"
+
 # The base directory where everything should be installed.
 prefix  = /usr/local
 
@@ -132,6 +138,13 @@ ifneq (, $(shell which pkg-config))
     CFLAGS += -DXLSX_EXPORT $(shell pkg-config --cflags xlsxwriter)
     LDLIBS += $(shell pkg-config --libs xlsxwriter)
   endif
+
+  # NOTE: compile with required libxlsxwriter for export support on Cygwin
+  ifeq ($(O_CYGWIN), 1) 
+    CFLAGS += -DXLSX_EXPORT -I$(prefix)/include 
+    LDLIBS += -I $(prefix)/include -L $(O_LIBXLSXWRITER_ROOT)/lib 
+    LDLIBS += -lxlsxwriter -lz 
+  endif 
 
   # NOTE: lua support
   LUA_PKGNAME ?= $(shell pkg-config --list-all | awk '/^lua-?[0-9.]+[[:space:]]/ { p=$$1; gsub("[^[0-9]", "", p); print p " " $$1; }' | LC_ALL=C sort -nrk1 | uniq | head -n 1 | awk '{print $$2}')

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,8 +4,8 @@ name = sc-im
 # Specify some Options
 
 ## Build in cygwin environment with previously compiled libxlsxwriter
-O_CYGWIN := 0 		
-O_LIBXLSXWRITER_ROOT := "../../libxlsxwriter"
+O_CYGWIN ::= 0 		
+O_LIBXLSXWRITER_ROOT ::= "../../libxlsxwriter"
 
 # The base directory where everything should be installed.
 prefix  = /usr/local


### PR DESCRIPTION
To make the software available to windows user, some flags have been added to make easy and straightforward to build the tool on [Cygwin](https://www.cygwin.com/). 

Two flags have been added: 
- `O_CYGWIN` which activate building for cygwin.
- `O_LIBXLSXWRITER_ROOT` which points to the root of the `libxlsxwriter` cloned project.

To link `libxlsxwriter`, the makefile is relying on pkg-config to detect if the library is correctly installed, which does not work on cygwin since `ldconfig` does not exist. Therefore the library should be linked manually. And that is exactly what this PR is enabling. 

N.B: Guides on how to build on windows environment will be added after the merge.
N.B: The build has been tested on the latest cygwin environment available v3.4.9.