### PR TITLE
Add commands to modify edit mode keybindings

### DIFF
--- a/src/cmds/cmds_command.c
+++ b/src/cmds/cmds_command.c
@@ -115,6 +115,9 @@ L"e txt",
 L"e! txt",
 L"e xlsx",
 L"e! xlsx",
+L"emap",
+L"enoremap",
+L"eunmap",
 L"fcopy",
 L"file",
 L"fill",
@@ -973,13 +976,16 @@ void do_commandmode(struct block * sb) {
 
         } else if ( ! wcsncmp(inputline, L"nmap", 4) ||
                     ! wcsncmp(inputline, L"imap", 4) ||
+                    ! wcsncmp(inputline, L"emap", 4) ||
                     ! wcsncmp(inputline, L"vmap", 4) ||
                     ! wcsncmp(inputline, L"cmap", 4) ||
                     ! wcsncmp(inputline, L"inoremap", 8) ||
+                    ! wcsncmp(inputline, L"enoremap", 8) ||
                     ! wcsncmp(inputline, L"nnoremap", 8) ||
                     ! wcsncmp(inputline, L"vnoremap", 8) ||
                     ! wcsncmp(inputline, L"cnoremap", 8) ||
                     ! wcsncmp(inputline, L"iunmap", 6) ||
+                    ! wcsncmp(inputline, L"eunmap", 6) ||
                     ! wcsncmp(inputline, L"vunmap", 6) ||
                     ! wcsncmp(inputline, L"cunmap", 6) ||
                     ! wcsncmp(inputline, L"nunmap", 6) ) {

--- a/src/doc
+++ b/src/doc
@@ -575,6 +575,11 @@ Commands for handling cell content:
                  only in INSERT_MODE.
                  Example:  :imap "<C-f>" "format"
 
+     :emap {lhs} {rhs}
+                 Map the key sequence {lhs} to {rhs} This mapping takes effect
+                 only in EDIT_MODE.
+                 Example:  :emap "<C-k>" "D"
+
      :vmap {lhs} {rhs}
                  Map the key sequence {lhs} to {rhs} This mapping takes effect
                  only in VISUAL_MODE.
@@ -594,6 +599,10 @@ Commands for handling cell content:
                  This is the non-recursive version of ":imap". See NOTES on
                  MAPPING below
 
+     :enoremap {lhs} {rhs}
+                 This is the non-recursive version of ":emap". See NOTES on
+                 MAPPING below
+
      :vnoremap {lhs} {rhs}
                  This is the non-recursive version of ":vmap". See NOTES on
                  MAPPING below
@@ -609,6 +618,10 @@ Commands for handling cell content:
      :iunmap {lhs}
                  Remove the map sequence {lhs} that takes effect in
                  INSERT_MODE.
+
+     :eunmap {lhs}
+                 Remove the map sequence {lhs} that takes effect in
+                 EDIT_MODE.
 
      :vunmap {lhs}
                  Remove the map sequence {lhs} that takes effect in
@@ -1191,13 +1204,13 @@ Commands for handling cell content:
 
     Mapping can be done in any sc-im file or in CONFIG_DIR/scimrc file.
 
-    Maps can be added with the :nmap, :imap, :cmap and :vmap commands and removed
-    with the :nunmap, :iunmap, :cunmap and :vunmap commands.
+    Maps can be added with the :nmap, :imap, :emap, :cmap and :vmap commands and
+    removed with the :nunmap, :iunmap, :cunmap and :vunmap commands.
     Example:
         :nmap "d" ":h<cr>"  ->   Maps d to ':help<cr>' in Normal mode.
         :imap "f" "foo"     ->   Maps f to the string 'foo' in Insert mode.
-        :imap "f" "foo"     ->   Maps f to the string 'foo' in Insert mode.
         :imap "kj" "<ESC>"  ->   Maps kj sequence to the ESC key in Insert mode.
+        :emap "<C-k>" "D"   ->   Maps C-k to D in Edit mode.
         :cmap "kj" "<ESC>"  ->   Maps kj sequence to the ESC key in Command mode.
         :vmap "e" "y"       ->   Maps e to y in Visual mode.
 
@@ -1210,7 +1223,8 @@ Commands for handling cell content:
 
     If an existing map sequence is remapped, it is replaced with the new one.
     Mapping is recursive by default. The non-recursive versions of :nmap,
-    :imap, :cmap and :vmap are :nnoremap, :inoremap, :cnoremap and :vnoremap.
+    :imap, :emap, :cmap and :vmap are :nnoremap, :inoremap, :enoremap,
+    :cnoremap and :vnoremap.
     Example:
         nmap "a" "b",
         nnoremap "b" "j"
@@ -2069,10 +2083,13 @@ Commands for handling cell content:
     UNLOCK {var_or_range}
     NMAP {STRING} {STRING}
     IMAP {STRING} {STRING}
+    EMAP {STRING} {STRING}
     NNOREMAP {STRING} {STRING}
     INOREMAP {STRING} {STRING}
+    ENOREMAP {STRING} {STRING}
     NUNMAP {STRING}
     IUNMAP {STRING}
+    EUNMAP {STRING}
     COLOR {STRING}
     CELLCOLOR {var_or_range} {STRING}
     TRIGGER {var_or_range} {STRING}

--- a/src/gram.y
+++ b/src/gram.y
@@ -211,6 +211,7 @@ token S_YANKCOL
 %token S_REDO
 %token S_UNDO
 %token S_IMAP
+%token S_EMAP
 %token S_CMAP
 %token S_NEWSHEET
 %token S_NEXTSHEET
@@ -221,11 +222,13 @@ token S_YANKCOL
 %token S_NMAP
 %token S_VMAP
 %token S_INOREMAP
+%token S_ENOREMAP
 %token S_CNOREMAP
 %token S_NNOREMAP
 %token S_VNOREMAP
 %token S_NUNMAP
 %token S_IUNMAP
+%token S_EUNMAP
 %token S_CUNMAP
 %token S_VUNMAP
 %token S_COLOR
@@ -921,6 +924,11 @@ command:
                                    scxfree($2);
                                    scxfree($3);
                                  }
+    |    S_EMAP STRING STRING    {
+                                   add_map($2, $3, EDIT_MODE, 1);
+                                   scxfree($2);
+                                   scxfree($3);
+                                 }
     |    S_VMAP STRING STRING    {
                                    add_map($2, $3, VISUAL_MODE, 1);
                                    scxfree($2);
@@ -942,6 +950,11 @@ command:
                                    scxfree($2);
                                    scxfree($3);
                                    }
+    |    S_ENOREMAP STRING STRING  {
+                                   add_map($2, $3, EDIT_MODE, 0);
+                                   scxfree($2);
+                                   scxfree($3);
+                                   }
     |    S_VNOREMAP STRING STRING  {
                                    add_map($2, $3, VISUAL_MODE, 0);
                                    scxfree($2);
@@ -960,6 +973,10 @@ command:
 
     |    S_IUNMAP STRING           {
                                    del_map($2, INSERT_MODE);
+                                   scxfree($2);
+                                   }
+    |    S_EUNMAP STRING           {
+                                   del_map($2, EDIT_MODE);
                                    scxfree($2);
                                    }
     |    S_VUNMAP STRING           {


### PR DESCRIPTION
Add commands `:e{,un,nore}map`. The new commands have the exact same code and behaviour as the mapping commands for the other four modes. This was suggested in https://github.com/andmarti1424/sc-im/issues/692.

I have tested them using both the `scimrc` file and the interactive command mode.