### PR TITLE
fixed compiler error related to missing include

### DIFF
--- a/src/formats/ods.c
+++ b/src/formats/ods.c
@@ -50,6 +50,7 @@
 #include <errno.h>
 #include <zip.h>
 #include <libxml/parser.h>
+#include <stdlib.h>
 
 #include "../tui.h"
 #include "../cmds/cmds.h"


### PR DESCRIPTION
I went to install this program on my arch machine and saw compilation had failed. Seemed that ods.c was missing an include for the free() calls.