### PR TITLE
Feature/explicit left markdown alignment

### DIFF
--- a/examples/markdown/markdown-table-alignment.md
+++ b/examples/markdown/markdown-table-alignment.md
@@ -1,6 +1,6 @@
-| Ingredient |     Amount |       unit |
-|-----------:|-----------:|-----------:|
-|   Sardines |       1.00 |       kilo |
-|    Garlick |       3.00 |       toes |
-|    Parsley |       1.00 |      bunch |
-| White wine |       1.00 |     bottle |
+| Ingredient (def: left) | Shop: (left)       | Amount (right) | Unit (center) |
+|------------------------|:-------------------|---------------:|:-------------:|
+| Sardines               | Fish Market        |           1.00 |     kilo      |
+| Garlick                | Vegetables Inc.    |           3.00 |     toes      |
+| Parsley                | Vegetables Inc.    |           1.00 |     bunch     |
+| White wine             | Rosemary's Spirits |           1.00 |    bottle     |

--- a/src/file.c
+++ b/src/file.c
@@ -1583,7 +1583,7 @@ void export_markdown(char * fname, int r0, int c0, int rn, int cn) {
                 // Column alignment is bases on cell alignments of first row
                 if (row == 0) {
                     if (col == c0) strcat (dashline, "|");
-                    if (align == 0) {
+                    if (align == 0 || align == -1) {
                         strcat (dashline, ":");
                     } else {
                         strcat (dashline, "-");


### PR DESCRIPTION
Instead of exporting `|---------|` when alignment is set to `left`, this PR make sc-im explicitly export `|:----------|` when alignment is set to `left`. This improves complience with Pandoc, Latex and Quarto who all treat `|-------|` as center alignment.