### PR TITLE
fix spurious circular deps across sheets (issue #903)

### DIFF
--- a/src/graph.c
+++ b/src/graph.c
@@ -772,7 +772,7 @@ void EvalRange(struct sheet * sh, int tlrow, int tlcol, int brrow, int brcol) {
             for (i = 0; deps != NULL && i < deps->vf; i++) {
                 f = *ATBL(deps[i].sheet, deps[i].sheet->tbl, deps[i].vp->row, deps[i].vp->col);
                 if (f == NULL || ! f->expr) continue;
-                EvalJustOneVertex(sh, f, 0);
+                EvalJustOneVertex(deps[i].sheet, f, 0);
             }
             if (deps != NULL) free(deps);
             deps = NULL;


### PR DESCRIPTION
Issue #903

It looks to me that the the test for the cell is being carried out on the sheet containing the cell rather than the one containing the dep.  

Testing this fixes the observed bug, but I'm not confident that I understand the code well enough not to break something else!