### PR TITLE
fix spurious error message with @IF command issue #910

### DIFF
--- a/src/interp.c
+++ b/src/interp.c
@@ -628,7 +628,7 @@ char * seval(struct sheet * sh, struct ent * ent, struct enode * se, int rebuild
 
     case IF:
 
-    case '?':    return (eval(sh, NULL, se->e.o.left, rebuild_graph) ? seval(sh, ent, se->e.o.right->e.o.left, rebuild_graph) : seval(sh, ent, se->e.o.right->e.o.right, rebuild_graph));
+    case '?':    return (eval(sh, ent, se->e.o.left, rebuild_graph) ? seval(sh, ent, se->e.o.right->e.o.left, rebuild_graph) : seval(sh, ent, se->e.o.right->e.o.right, rebuild_graph));
 
     case DATE:   return (dodate( (time_t) (eval(sh, ent, se->e.o.left, rebuild_graph)), seval(sh, ent, se->e.o.right, rebuild_graph)));
 


### PR DESCRIPTION
IF: case in `seval` calls `eval` with `ent` set to NULL which allways causes an error message and an incorrect dep graph
see issue #910