### PR TITLE
fix: pasted expressions not in graph

### DIFF
--- a/src/actions/sort.c
+++ b/src/actions/sort.c
@@ -56,6 +56,7 @@
 #include "../cmds/cmds.h"
 #include "../conf.h"
 #include "../color.h"
+#include "../graph.h"
 #include "../xmalloc.h" // for scxfree
 
 int compare(const void * row1, const void * row2);
@@ -182,6 +183,7 @@ void sortrange(struct sheet * sh, struct ent * left, struct ent * right, char * 
 
     scxfree((char *) sort);
     scxfree((char *) rows);
+    rebuild_graph();
 
     if (criteria) scxfree(criteria);
 }

--- a/src/cmds/cmds_normal.c
+++ b/src/cmds/cmds_normal.c
@@ -659,6 +659,7 @@ void do_normalmode(struct block * buf) {
                     sc_error("Locked cells encountered. Nothing changed");
                     break;
                 }
+                rebuild_graph();
 
             // if m represents just one cell
             } else {
@@ -910,6 +911,7 @@ void do_normalmode(struct block * buf) {
                 sc_error("Locked cells encountered. Nothing changed");
                 break;
             }
+            rebuild_graph();
             ui_update(TRUE);
             break;
 
@@ -922,6 +924,7 @@ void do_normalmode(struct block * buf) {
                     sc_error("Locked cells encountered. Nothing changed");
                     break;
                 }
+                rebuild_graph();
                 ui_update(TRUE);
             }
             break;

--- a/src/cmds/cmds_visual.c
+++ b/src/cmds/cmds_visual.c
@@ -57,6 +57,7 @@
 #include "../actions/freeze.h"
 #include "../history.h"
 #include "../interp.h"
+#include "../graph.h"
 #ifdef UNDO
 #include "../undo.h"
 #endif
@@ -482,6 +483,7 @@ void do_visualmode(struct block * buf) {
             }
             exit_visualmode();
             chg_mode('.');
+            rebuild_graph();
             ui_show_header();
 #ifdef DEBUG
             sc_info(str);

--- a/src/gram.y
+++ b/src/gram.y
@@ -1245,6 +1245,7 @@ command:
                                      if ((sh = search_sheet(roman, $3)) == NULL )
                                          sh = roman->cur_sh;
                                      paste_yanked_ents(sh, $5, $6[0]);
+                                     rebuild_graph();
                                      scxfree($3);
                                      scxfree($6);
                                    }


### PR DESCRIPTION
Adds a call to `rebuild_graph()` after each call to ` paste_yanked_ents(...)`.

See issue #