### PR TITLE
fix crashes in replace (from recent patch) and sevaluate (issue #919)

### DIFF
--- a/src/function.c
+++ b/src/function.c
@@ -1024,7 +1024,8 @@ char * doreplace(char * source, char * old, char * newstr) {
     }else{
         ret = str_replace(source, old, newstr);
         scxfree(old);
-        scxfree(newstr);
+        if(newstr != NULL)
+            scxfree(newstr);
         scxfree(source);
     }
     return ret;
@@ -1070,16 +1071,17 @@ char * dosubstr(char * s, int v1, int v2) {
  */
 char * dosevaluate(char * s) {
     if ( !s ) return ((char *) 0);
-    char * p;
+    char * p=NULL;
 
     wchar_t cline [BUFFERSIZE];
     swprintf(cline, BUFFERSIZE, L"seval %s", s);
     send_to_interp(cline);
 
-    p = scxmalloc(sizeof(char) * strlen(seval_result)+1);
-    strcpy(p, seval_result);
-    free(seval_result);
-
+    if(seval_result != NULL){
+        p = scxmalloc(sizeof(char) * strlen(seval_result)+1);
+        strcpy(p, seval_result);
+        free(seval_result);
+    }
     scxfree(s);
     return p;
 }

--- a/tests/test-replace.sh
+++ b/tests/test-replace.sh
@@ -24,7 +24,19 @@ getstring a1\n
 getstring a2\n
 getstring a3\n
 getstring a4\n
-getstring a5
+getstring a5\n
+'
+CMD2='
+let C1 = 3\n
+let D1 = 4\n
+let E1 = 1\n
+let F1 = 2\n
+let B54 = 5\n
+rightstring B55 = @coltoa(B54)#"1"\n
+rightstring B56 = @replace("@sum(d1:0)","0",B55)\n
+let B57 = @evaluate(B56)\n
+recalc\n
+getnum b57
 '
 export IFS=$'\n'
 EXP="\
@@ -49,6 +61,7 @@ assert_iffound_notcond ${NAME}_vallog "Conditional jump or move depends on unini
 assert_iffound_notcond ${NAME}_vallog "Invalid read of size"
 assert_iffound_notcond ${NAME}_vallog "Invalid write of size"
 assert_iffound_notcond ${NAME}_vallog "Invalid free() / delete"
+assert "echo -e '${CMD2}' |../src/sc-im --nocurses --nodebug --quit_afterload 2>&1" 7
 if [ "$1" != "keep-vallog" ];then
    rm ${NAME}_vallog
 fi


### PR DESCRIPTION
Recent PR fixing a crash in replace failed to take account of possible NULL second argument.
 (issue #919)
Testing also revealed a segfault in `sevaluate` if the input is invalid.