### PR TITLE
Fix: invalid chars in file name cause segfault

### DIFF
--- a/src/file.h
+++ b/src/file.h
@@ -72,6 +72,7 @@ void remove_backup(char * file);
 int backup_exists(char * file);
 void openfile_nested(char * file);
 void openfile_under_cursor(int r, int c);
+static const char *worderror(int errnum);
 
 // load functions
 void load_file(char * loading_file);


### PR DESCRIPTION
If invalid filename `wordexp` creates an absurdly large value in `p.we_wordc` which in turn leads to an invalid pointer write.