### PR TITLE
Changing the makefile for a better definition of the prefix, added 2 new color definitions for theme using 2 colors for colums, which collided with the help file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ src/debug.sh
 src/debuga.sh
 src/a.sc
 src/lua
+src/local.mk
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,17 @@
 # Specify the name of the resulting executable file
 name = sc-im
 
-# The base directory where everything should be installed.
-prefix  = /home/rako/.local
+# The base directory of the installation can be defined in 
+# the file local.mk  The variable prefix has to be set in that file.
+# Otherwise the default value is /usr/local
+
+-include local.mk 
+
+ifndef prefix
+prefix = /usr/local
+endif
+
+$(info Installation prefix directory is $(prefix))
 
 EXDIR   = $(prefix)/bin
 HELPDIR = $(prefix)/share/$(name)

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@
 name = sc-im
 
 # The base directory where everything should be installed.
-prefix  = /usr/local
+prefix  = /home/rako/.local
 
 EXDIR   = $(prefix)/bin
 HELPDIR = $(prefix)/share/$(name)

--- a/src/color.c
+++ b/src/color.c
@@ -162,7 +162,9 @@ void start_default_ucolors() {
     ucolors[ FILENM          ].fg = GREEN;
     ucolors[ FILENM          ].bg = DEFAULT_COLOR;
     ucolors[ HELP_TEXT       ].fg = WHITE;
-    ucolors[ HELP_TEXT       ].bg = BLACK;
+    ucolors[ HELP_TEXT       ].fg = WHITE;
+    ucolors[ HELP_KEYDEF     ].fg = WHITE;
+    ucolors[ HELP_KEYDEF     ].bg = BLACK;
 
     ui_start_colors(); // call specific ui startup routine
 }
@@ -260,6 +262,8 @@ void set_colors_param_dict() {
     put(d_colors_param, "FILENM", str);
     sprintf(str, "%d", HELP_TEXT);
     put(d_colors_param, "HELP_TEXT", str);
+    sprintf(str, "%d", HELP_KEYDEF);
+    put(d_colors_param, "HELP_KEYDEF", str);
 }
 
 /**

--- a/src/color.c
+++ b/src/color.c
@@ -161,6 +161,8 @@ void start_default_ucolors() {
     ucolors[ SHEET           ].bg = DEFAULT_COLOR;
     ucolors[ FILENM          ].fg = GREEN;
     ucolors[ FILENM          ].bg = DEFAULT_COLOR;
+    ucolors[ HELP_TEXT       ].fg = WHITE;
+    ucolors[ HELP_TEXT       ].bg = BLACK;
 
     ui_start_colors(); // call specific ui startup routine
 }
@@ -256,6 +258,8 @@ void set_colors_param_dict() {
     put(d_colors_param, "SHEET", str);
     sprintf(str, "%d", FILENM);
     put(d_colors_param, "FILENM", str);
+    sprintf(str, "%d", HELP_TEXT);
+    put(d_colors_param, "HELP_TEXT", str);
 }
 
 /**

--- a/src/color.h
+++ b/src/color.h
@@ -48,7 +48,7 @@
 #include <math.h>
 #define RGB(r, g, b)    r*999/255, g*999/255, b*999/255
 
-#define N_INIT_PAIRS      28
+#define N_INIT_PAIRS      29
 
 #define HEADINGS          0
 #define WELCOME           1
@@ -78,6 +78,7 @@
 #define SHEET             25
 #define CURRENT_SHEET     26
 #define FILENM            27
+#define HELP_TEXT         28
 
 struct ucolor {
     int fg;

--- a/src/color.h
+++ b/src/color.h
@@ -48,7 +48,7 @@
 #include <math.h>
 #define RGB(r, g, b)    r*999/255, g*999/255, b*999/255
 
-#define N_INIT_PAIRS      29
+#define N_INIT_PAIRS      30
 
 #define HEADINGS          0
 #define WELCOME           1
@@ -79,6 +79,7 @@
 #define CURRENT_SHEET     26
 #define FILENM            27
 #define HELP_TEXT         28
+#define HELP_KEYDEF       29
 
 struct ucolor {
     int fg;

--- a/src/doc
+++ b/src/doc
@@ -892,7 +892,7 @@ Commands for handling cell content:
                      CELL_ERROR, CELL_NEGATIVE, CELL_SELECTION,
                      CELL_SELECTION_SC, INFO_MSG, ERROR_MSG, CELL_ID,
                      CELL_FORMAT, CELL_CONTENT, WELCOME, NORMAL, INPUT,
-                     HELP_HIGHLIGHT.
+                     HELP_HIGHLIGHT, HELP_TEXT, HELP_KEYDEF.
 
                 The value of fg and bg shall be one of the following:
                      WHITE, BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN,
@@ -966,6 +966,9 @@ Commands for handling cell content:
                           input bar at the top left of the screen.
                         - HELP_HIGHLIGHT Color used for highlighting search results
                           and titles of help page.
+                        - HELP_TEXT Color used for the text of the help page.
+                        - HELP_KEYDEF Color used for the key definitions in the
+                          help page.
 
     :cellcolor "{key}={arg} .."
                 Change the color of the current cell or range.

--- a/src/help.c
+++ b/src/help.c
@@ -411,7 +411,7 @@ int show_lines() {
                 #endif
             } else if (key) {
                 #ifdef USECOLORS
-                ui_set_ucolor(main_win, &ucolors[NUMB], DEFAULT_COLOR);
+                ui_set_ucolor(main_win, &ucolors[HELP_KEYDEF], DEFAULT_COLOR);
                 #endif
             }
 

--- a/src/help.c
+++ b/src/help.c
@@ -385,7 +385,7 @@ int show_lines() {
             #ifdef USECOLORS
             bold && ! key?
             ui_set_ucolor(main_win, &ucolors[HELP_HIGHLIGHT], DEFAULT_COLOR) :
-            ui_set_ucolor(main_win, &ucolors[NORMAL], DEFAULT_COLOR);
+            ui_set_ucolor(main_win, &ucolors[HELP_TEXT], DEFAULT_COLOR);
             #endif
 
             if (long_help[lineno + delta][i] == '<' || long_help[lineno + delta][i] == '{') {

--- a/themes/duo-color.sc
+++ b/themes/duo-color.sc
@@ -1,0 +1,41 @@
+DEFINE_COLOR "comment" 121 112 169
+DEFINE_COLOR "altbackground" 63 63 63
+DEFINE_COLOR "BG1" 254 247 219
+DEFINE_COLOR "BG2" 244 221 178
+DEFINE_COLOR "BG_SELECT" 129 162 190
+DEFINE_COLOR "EXP" 129 162 190
+DEFINE_COLOR "STR" 129 162 190
+DEFINE_COLOR "DATE" 129 162 190
+DEFINE_COLOR "HEADER1" 126 126 126
+DEFINE_COLOR "HEADER2" 228 228 228
+DEFINE_COLOR "HEADERTXT" 188 182 106
+
+color "type=WELCOME fg=YELLOW bg=BLACK bold=0"
+color "type=NORMAL fg=WHITE bg=NONE_COLOR bold=0"
+color "type=DEFAULT fg=WHITE bg=BLACK bold=0 italic=0"
+color "type=FILENM fg=WHITE bg=BLACK bold=1"
+color "type=SHEET fg=comment bg=BG1 bold=0"
+color "type=CURRENT_SHEET fg=WHITE bg=BLACK bold=1"
+color "type=MODE fg=WHITE bg=BLACK bold=0"
+color "type=INFO_MSG fg=WHITE bg=BLACK bold=1"
+color "type=ERROR_MSG fg=RED bg=BLACK bold=1"
+color "type=INPUT fg=WHITE bg=BLACK bold=1"
+color "type=HEADINGS fg=HEADERTXT bg=HEADER1 bold=0"
+color "type=HEADINGS_ODD fg=HEADERTXT bg=HEADER2 bold=0"
+color "type=CELL_ID fg=WHITE bg=BLACK bold=0"
+color "type=CELL_FORMAT fg=WHITE bg=BLACK bold=0"
+color "type=CELL_CONTENT fg=WHITE bg=BLACK bold=0"
+color "type=CELL_ERROR fg=BLACK bg=RED bold=1"
+color "type=CELL_NEGATIVE fg=BLACK bg=NONE_COLOR bold=0 reverse=0"
+color "type=CELL_SELECTION fg=WHITE bg=BG_SELECT bold=0"
+color "type=CELL_SELECTION_SC fg=WHITE bg=BG_SELECT bold=1"
+color "type=NUMB fg=BLACK bg=NONE_COLOR bold=0"
+color "type=STRG fg=STR bg=NONE_COLOR bold=0 italic=0"
+color "type=DATEF fg=DATE bg=NONE_COLOR"
+color "type=GRID_EVEN fg=GREEN bg=BG1"
+color "type=GRID_ODD fg=WHITE bg=BG2"
+color "type=EXPRESSION fg=EXP bg=NONE_COLOR bold=0"
+color "type=HELP_TEXT fg=WHITE bg=BLACK bold=0"
+color "type=HELP_HIGHLIGHT fg=WHITE bg=BLACK bold=1"
+color "type=HELP_KEYDEF fg=YELLOW bg=BLACK bold=1"
+


### PR DESCRIPTION
I made a theme with a color for odd and even columns, which demanded the use of NONE_COLOR for DEFAULT.  But this made it impossible to get a good color definition for help, since help is using DEFAULT. Instead of changing the drawing order, I added 2 color definitions HELP_TEXT and HELP_KEYDEF to the code, which makes more sense to have full control. The file doc was updated as well. 

To avoid a change of prefix in the Makefile is changing the  repo, I changed the Makefile so that an optional file local.mk is included to define the prefix. The file local.mk is ignored by git. 

