### PR TITLE
Add `movesheet` and enable `movetosheet` commands

### DIFF
--- a/src/cmds/cmds_command.c
+++ b/src/cmds/cmds_command.c
@@ -144,6 +144,7 @@ L"load!",
 L"load",
 L"lock",
 L"movesheet",
+L"movetosheet",
 L"newsheet",
 L"nextsheet",
 L"nmap",
@@ -970,6 +971,7 @@ void do_commandmode(struct block * sb) {
             ui_show_text(valores);
 
         } else if ( ! wcsncmp(inputline, L"movesheet", 9) ||
+                    ! wcsncmp(inputline, L"movetosheet", 10) ||
                     ! wcsncmp(inputline, L"newsheet", 8) ||
                     ! wcsncmp(inputline, L"delsheet", 8) ||
                     ! wcsncmp(inputline, L"nextsheet", 9) ||

--- a/src/cmds/cmds_command.c
+++ b/src/cmds/cmds_command.c
@@ -143,6 +143,7 @@ L"iunmap",
 L"load!",
 L"load",
 L"lock",
+L"movesheet",
 L"newsheet",
 L"nextsheet",
 L"nmap",
@@ -968,7 +969,8 @@ void do_commandmode(struct block * sb) {
             get_mappings(valores);
             ui_show_text(valores);
 
-        } else if ( ! wcsncmp(inputline, L"newsheet", 8) ||
+        } else if ( ! wcsncmp(inputline, L"movesheet", 9) ||
+                    ! wcsncmp(inputline, L"newsheet", 8) ||
                     ! wcsncmp(inputline, L"delsheet", 8) ||
                     ! wcsncmp(inputline, L"nextsheet", 9) ||
                     ! wcsncmp(inputline, L"renamesheet", 11) ||

--- a/src/doc
+++ b/src/doc
@@ -566,6 +566,12 @@ Commands for handling cell content:
      :renamesheet "{name}"
                  rename the current sheet to {name}.
 
+     :movesheet {position}
+                 Moves the current sheet to the specified position (0-based) in the sheet list.
+
+     :movetosheet "{name}"
+                 Switches to the sheet with the given name.
+
      :showmaps   Show all key mappings.
 
      :nmap {lhs} {rhs}

--- a/src/gram.y
+++ b/src/gram.y
@@ -219,6 +219,7 @@ token S_YANKCOL
 %token S_PREVSHEET
 %token S_DELSHEET
 %token S_MOVETOSHEET
+%token S_MOVESHEET
 %token S_RENAMESHEET
 %token S_NMAP
 %token S_VMAP
@@ -901,13 +902,20 @@ command:
                                    ui_update(TRUE);
                                  }
 
-    |    S_MOVETOSHEET STRING    {
-                                   struct sheet * sh;
-                                   if ((sh = search_sheet(session->cur_doc, $2)) != NULL )
-                                       session->cur_doc->cur_sh = sh;
-                                   scxfree($2);
-                                 }
-    |    S_RENAMESHEET STRING    {
+     |    S_MOVETOSHEET STRING    {
+                                    struct sheet * sh;
+                                    if ((sh = search_sheet(session->cur_doc, $2)) != NULL )
+                                        session->cur_doc->cur_sh = sh;
+                                    scxfree($2);
+                                  }
+     |    S_MOVESHEET NUMBER       {
+                                    struct roman * roman = session->cur_doc;
+                                    move_sheet_to_position(roman, $2);
+                                    roman->modflg++;
+                                    chg_mode('.');
+                                    ui_update(TRUE);
+                                  }
+     |    S_RENAMESHEET STRING    {
                                    struct sheet * sh = session->cur_doc->cur_sh;
                                    if (sh->name != NULL) free(sh->name);
                                    session->cur_doc->modflg++;

--- a/src/sc.h
+++ b/src/sc.h
@@ -495,6 +495,7 @@ extern void colshow_op();
 extern struct colorpair *cpairs[8];
 extern void efree(struct enode * e);
 extern void label(struct ent * v, char * s, int flushdir);
+extern int move_sheet_to_position(struct roman * doc, int position);
 
 extern double eval_result;
 extern char * seval_result;

--- a/src/sheet.c
+++ b/src/sheet.c
@@ -232,3 +232,47 @@ void delete_sheet(struct roman * roman, struct sheet * sh, int flg_free) {
     return;
 }
 
+/**
+ * \brief move_sheet_to_position()
+ * \param[doc] roman struct
+ * \param[position] 0-based position to move current sheet to
+ * \return int 0 on success
+ */
+int move_sheet_to_position(struct roman * doc, int position) {
+    struct sheet * sh = doc->cur_sh;
+    int num_sheets = get_num_sheets(doc);
+    if (num_sheets <= 1) return 0; // nothing to do
+
+    if (position < 0) position = 0;
+    if (position >= num_sheets) position = num_sheets - 1;
+
+    // remove from list
+    REMOVE(sh, doc->first_sh, doc->last_sh, next, prev);
+
+    // now insert at position
+    if (position == 0) {
+        // insert at beginning
+        INSERT_BEFORE(sh, doc->first_sh, doc->last_sh, next, prev);
+    } else {
+        // find the sheet before position
+        struct sheet * prev = doc->first_sh;
+        int i = 1;
+        while (prev && i < position) {
+            prev = prev->next;
+            i++;
+        }
+        // now prev is the sheet at position-1, insert after it
+        if (prev) {
+            sh->next = prev->next;
+            sh->prev = prev;
+            if (prev->next) prev->next->prev = sh;
+            prev->next = sh;
+            if (sh->next == NULL) doc->last_sh = sh;
+        } else {
+            // shouldn't happen
+            INSERT(sh, doc->first_sh, doc->last_sh, next, prev);
+        }
+    }
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
This PR adds a new movesheet command to reposition sheets within the document to a specified 0-based position, enhancing sheet management functionality. It also includes fixes to the existing movetosheet command for switching sheets by name.

## Changes
- src/cmds/cmds_command.c: Added "movesheet" and "movetosheet" to the command list and command mode handler.
- src/gram.y: Added S_MOVESHEET token and grammar rule for movesheet <number> to invoke sheet repositioning.
- src/sc.h: Added extern declaration for move_sheet_to_position function.
- src/sheet.c: Implemented move_sheet_to_position function to safely move the current sheet to the desired position in the sheet list, handling edge cases like invalid positions and single-sheet documents.