### PR TITLE
Repsect external prefix variable if set

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@
 name = sc-im
 
 # The base directory where everything should be installed.
-prefix  = /usr/local
+prefix  ?= /usr/local
 
 EXDIR   = $(prefix)/bin
 HELPDIR = $(prefix)/share/$(name)


### PR DESCRIPTION
Sometimes users want to install sc-im in locations other than /usr/local This will allow them choosing destination location without patching of Makefile