### PR TITLE
Add sheet numbers and cmd 'movetosheet <number>'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,9 @@ this could allow future use of registers to copy to and paste from.
 
 *********
 v0.8.6
+07/05/2026: Show 1-based sheet numbers in the header ({n:name}), toggled by
+            the new 'show_sheet_numbers' conf (default on). Jump to a sheet by
+            number with :movetosheet {n} or the gs command ({count}gs).
 01/28/2026: Added movesheet and movetosheet commands
 11/12/2025: fix in graph when using @SUBSTR
             fix wordexp return value

--- a/src/cmds/cmds.c
+++ b/src/cmds/cmds.c
@@ -2929,6 +2929,7 @@ int is_single_command (struct block * buf, long timeout) {
                  buf->pnext->value == L'l' ||
                  buf->pnext->value == L't' ||
                  buf->pnext->value == L'T' ||
+                 buf->pnext->value == L's' ||
                  buf->pnext->value == L'$'))
                  result = MOVEMENT_CMD;
 

--- a/src/cmds/cmds_normal.c
+++ b/src/cmds/cmds_normal.c
@@ -407,6 +407,10 @@ void do_normalmode(struct block * buf) {
                 (void) swprintf(interp_line, BUFFERSIZE, L"prevsheet");
                 send_to_interp(interp_line);
 
+            } else if (buf->pnext->value == L's') {                        // gs (goto sheet by 1-based number; bare gs -> sheet 1)
+                (void) swprintf(interp_line, BUFFERSIZE, L"movetosheet %d", cmd_multiplier ? cmd_multiplier : 1);
+                send_to_interp(interp_line);
+
             } else if (buf->pnext->value == L'o') {                        // goA4 (goto cell A4)
                 (void) swprintf(interp_line, BUFFERSIZE, L"goto %s", parse_cell_name(2, buf));
                 send_to_interp(interp_line);

--- a/src/conf.c
+++ b/src/conf.c
@@ -75,6 +75,7 @@ const char default_config[] =
     "debug=0\n"
     "ignorecase=0\n"
     "show_cursor=0\n"
+    "show_sheet_numbers=1\n"
     "trigger=1\n"
     "version=0\n"
     "help=0\n"

--- a/src/doc
+++ b/src/doc
@@ -71,6 +71,8 @@ Navigation commands:
      gl          Go to the last (previously occupied) cell position.
      gt          Move to next sheet in file.
      gT          Move to previous sheet in file.
+     gs          Move to sheet number {count} (1-based); a bare gs moves to
+                 the first sheet. E.g. 3gs jumps to the third sheet.
      c-f   c-b   Scrolls down and up full screen.
                  :set half_page_scroll=1 to scroll by half a page instead.
                  half_page_scroll=0 (default) scrolls by a full page.
@@ -571,6 +573,11 @@ Commands for handling cell content:
 
      :movetosheet "{name}"
                  Switches to the sheet with the given name.
+
+     :movetosheet {number}
+                 Switches to the sheet at the given 1-based position in the
+                 current file. Out-of-range numbers are ignored. To reach a
+                 sheet whose name is a number, quote it: :movetosheet "3".
 
      :showmaps   Show all key mappings.
 
@@ -1454,6 +1461,11 @@ Commands for handling cell content:
     'show_cursor' [default off]
     Make the screen cursor follow the active cell. Useful for people
     using sc-im with a braille display.
+
+    'show_sheet_numbers' [default on]
+    Show a 1-based index in front of each sheet name in the header, as
+    {1:name}. The index is the number to use with the gs command or
+    :movetosheet to jump to that sheet. Set to 0 to hide the numbers.
 
     'ignore_hidden' [default off]
     set this if you want the hidden rows of a spreadsheet to be ignored when exporting them

--- a/src/gram.y
+++ b/src/gram.y
@@ -306,6 +306,8 @@ token S_YANKCOL
 %token K_NEWLINE_ACTION
 %token K_SHOW_CURSOR
 %token K_NOSHOW_CURSOR
+%token K_SHOW_SHEET_NUMBERS
+%token K_NOSHOW_SHEET_NUMBERS
 %token K_ERROR
 %token K_INVALID
 %token K_FIXED
@@ -907,6 +909,15 @@ command:
                                     if ((sh = search_sheet(session->cur_doc, $2)) != NULL )
                                         session->cur_doc->cur_sh = sh;
                                     scxfree($2);
+                                  }
+     |    S_MOVETOSHEET NUMBER    {
+                                    // jump to a sheet by its 1-based position in the current doc
+                                    struct sheet * sh = session->cur_doc->first_sh;
+                                    int n = $2;
+                                    while (n > 1 && sh != NULL) { sh = sh->next; n--; }
+                                    if (n == 1 && sh != NULL) session->cur_doc->cur_sh = sh;
+                                    chg_mode('.');
+                                    ui_update(TRUE);
                                   }
      |    S_MOVESHEET NUMBER       {
                                     struct roman * roman = session->cur_doc;
@@ -1822,5 +1833,10 @@ setitem :
                                      else         parse_str(user_conf_d, "show_cursor=1", TRUE); }
     |    K_SHOW_CURSOR            {               parse_str(user_conf_d, "show_cursor=1", TRUE); }
     |    K_NOSHOW_CURSOR          {               parse_str(user_conf_d, "show_cursor=0", TRUE); }
+
+    |    K_SHOW_SHEET_NUMBERS '=' NUMBER {  if ($3 == 0) parse_str(user_conf_d, "show_sheet_numbers=0", TRUE);
+                                     else         parse_str(user_conf_d, "show_sheet_numbers=1", TRUE); }
+    |    K_SHOW_SHEET_NUMBERS      {               parse_str(user_conf_d, "show_sheet_numbers=1", TRUE); }
+    |    K_NOSHOW_SHEET_NUMBERS    {               parse_str(user_conf_d, "show_sheet_numbers=0", TRUE); }
 
     ;

--- a/src/tui.c
+++ b/src/tui.c
@@ -1165,7 +1165,9 @@ void ui_show_celldetails() {
 
         // show sheets
         struct sheet * sh;
+        int sheet_num = 0;
         for (sh = rom->first_sh; sh != NULL; sh = sh->next) {
+            sheet_num++;
             if (sh == session->cur_doc->cur_sh) {
 #ifdef USECOLORS
                 ui_set_ucolor(input_win, &ucolors[CURRENT_SHEET], DEFAULT_COLOR);
@@ -1177,8 +1179,13 @@ void ui_show_celldetails() {
 #endif
                 if (get_conf_int("show_cursor")) mvwprintw(input_win, 0, il_pos++, " ");
             }
-            mvwprintw(input_win, 0, il_pos, "{%s}", sh->name);
-            il_pos += strlen(sh->name) + 2;
+            char sheet_lbl[FBUFLEN];
+            if (get_conf_int("show_sheet_numbers"))
+                snprintf(sheet_lbl, FBUFLEN, "{%d:%s}", sheet_num, sh->name);
+            else
+                snprintf(sheet_lbl, FBUFLEN, "{%s}", sh->name);
+            mvwprintw(input_win, 0, il_pos, "%s", sheet_lbl);
+            il_pos += strlen(sheet_lbl);
         }
         mvwprintw(input_win, 0, il_pos, "  ");
         il_pos += 2;


### PR DESCRIPTION
I added numbers to the sheets (`{1:sheet name}{2:other sheet}`)
Their display can be disabled by `set show_sheet_numbers=0`

Additionally I added an overload to `movetosheet`, which takes a number (instead of the string of a sheet name).
This cmd takes you directly to the sheet with the corresponding number.
It is mapped by default to `gs` (go sheet). 

The keybinding takes a count, which must be one of the sheet numbers.
If there is no count, it takes you to the first sheet.
If the number is not a sheet number, it's a no-op.
