### PR TITLE
Fix mouse click reliability and latency: select on button press

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -118,8 +118,7 @@ void handle_input(struct block * buffer) {
         d = wd;
 #ifdef MOUSE
         if (d == KEY_MOUSE) {
-            getmouse (&event);
-            ui_handle_mouse(event);
+            if (getmouse (&event) == OK) ui_handle_mouse(event);
             return;
         }
 #endif

--- a/src/tui.c
+++ b/src/tui.c
@@ -161,6 +161,12 @@ void ui_start_screen() {
     #ifdef MOUSE
     mmask_t old;
     mousemask (ALL_MOUSE_EVENTS, &old);
+    /* Act on button press rather than composed clicks: with a nonzero
+     * mouseinterval, ncurses holds each press for up to that interval
+     * waiting for the release to merge them into BUTTON1_CLICKED, which
+     * adds latency and drops events whose press/release timing falls
+     * outside the window (e.g. libinput tap-to-click or slow clicks). */
+    mouseinterval(0);
     #endif
 
     #ifndef NETBSD
@@ -1650,8 +1656,9 @@ void ui_handle_mouse(MEVENT event) {
     return;
 #endif
 
-    // return if not a single click
-    if (! (event.bstate & BUTTON1_CLICKED)) return;
+    // return if not a button1 press or click (BUTTON1_CLICKED can still
+    // arrive from drivers that compose clicks themselves, e.g. GPM)
+    if (! (event.bstate & (BUTTON1_PRESSED | BUTTON1_CLICKED))) return;
 
     // get coordinates corresponding to the grid area
     int c = event.x - sh->rescol;


### PR DESCRIPTION
**Problem**

Single-cell selection via mouse click is unreliable and laggy: clicks held longer than ~166 ms do nothing, every click pays a delay, and with libinput tap-to-click (touchpads) taps are ignored entirely.

**Root cause**

`ui_handle_mouse()` only reacts to `BUTTON1_CLICKED`, which the terminal never sends: ncurses synthesizes it by holding each press for up to `mouseinterval` (default 166 ms) waiting for the matching release. Presses longer than the interval are delivered as separate PRESSED/RELEASED events and both are discarded; libinput tap-to-click press/release pairs often arrive as separate events too, so they never compose into a click. `mouseinterval()` was never set.

**Fix**

- call `mouseinterval(0)` at startup so events are delivered immediately (no composition delay);
- select on `BUTTON1_PRESSED | BUTTON1_CLICKED` (CLICKED kept for drivers that compose clicks themselves, e.g. GPM);
- check the `getmouse()` return value before using the event, since the static MEVENT would otherwise be reused stale.

Wheel scrolling (`BUTTON4/5_PRESSED`) is unaffected. Nothing in the codebase uses double-clicks, so disabling their synthesis loses nothing.

Tested on kitty with SGR (1006) mouse mode and with the legacy 1000 protocol: physical clicks select instantly regardless of press duration, and trackpad tap-to-click now works.