### PR TITLE
Fix corrupted cellcolor fg on save for the first defined custom color

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -507,7 +507,10 @@ void write_fd(FILE * f, struct roman * doc) {
 
                         // decompile int value of color to its string description
                         if ((*pp)->ucolor->fg != NONE_COLOR) {
-                            if ((*pp)->ucolor->fg <= 8) {
+                            /* stock ncurses colors are 0..WHITE(7); custom color N
+                             * is stored as 7+N, so the first custom color is 8 and
+                             * must not fall into the stock-color decompile path */
+                            if ((*pp)->ucolor->fg <= WHITE) {
                                 linelim=0;
                                 struct enode * e = new((*pp)->ucolor->fg, (struct enode *)0, (struct enode *)0);
                                 decompile(e, 0);


### PR DESCRIPTION
**Problem**

If the first custom color created with `define_color` is used as `fg=` in a `cellcolor`, saving the file writes garbage instead of the color name, e.g.

    cellcolor A2:E2 "fg=^H?O E5

(a raw 0x08 byte followed by fragments of the last command parsed). Defining a throwaway color first makes the problem disappear, which shows only the first slot is affected.

**Root cause**

Stock curses colors are 0..7 (`WHITE`) and custom color N is stored in the cell as `7+N`, so the first custom color is exactly 8. In the save routine the fg branch tests `fg <= 8` while the bg branch correctly tests `bg <= WHITE`, so the first custom color takes the stock-color path: `decompile()` is called with token 8, which emits the raw byte 0x08 into the global `line` buffer on top of its stale content (the last parsed command), and that is what gets written to the file.

**Fix**

Test `fg <= WHITE`, matching the bg branch.

Repro: define two custom colors in scimrc, use the first one as fg in a cellcolor, save, inspect the file. After the fix the name round-trips intact through save/load/save.