### PR TITLE
Add depgraph edges for cell references inside @ext arguments

### DIFF
--- a/src/function.c
+++ b/src/function.c
@@ -925,13 +925,16 @@ char * dofmt(char * fmtstr, double v) {
  * \param[in] se
  * \return char *
  */
-char * doext(struct sheet * sh, struct enode *se) {
+char * doext(struct sheet * sh, struct ent * ent, struct enode *se) {
     char buff[FBUFLEN];        /* command line/return, not permanently alloc */
     char * command;
     double value;
 
-    command = seval(sh, NULL, se->e.o.left, 0);
-    value = eval(sh, NULL, se->e.o.right, 0);
+    /* pass the cell's ent down so cell references inside the @ext arguments
+     * are recorded as dependency edges in the graph; otherwise EvalBottomUp
+     * may evaluate this cell before its inputs (stale values on load) */
+    command = seval(sh, ent, se->e.o.left, 0);
+    value = eval(sh, ent, se->e.o.right, 0);
     if ( ! get_conf_int("external_functions") ) {
         sc_error("Warning: external functions disabled; using %s value",
         (se->e.o.s && *se->e.o.s) ? "previous" : "null");

--- a/src/function.h
+++ b/src/function.h
@@ -68,7 +68,7 @@ char * docat(char * s1, char * s2);
 #include <time.h>
 char * dodate(time_t tloc, char * fmtstr);
 char * dofmt(char * fmtstr, double v);
-char * doext(struct sheet * sh, struct enode * se);
+char * doext(struct sheet * sh, struct ent * ent, struct enode * se);
 char * dosval(struct sheet * sh, char * colstr, double rowdoub);
 char * dosubstr(char * s, int v1, int v2);
 char * docase(int acase, char * s);

--- a/src/interp.c
+++ b/src/interp.c
@@ -695,7 +695,7 @@ char * seval(struct sheet * sh, struct ent * ent, struct enode * se, int rebuild
     }
     case EXT:
              if (rebuild_graph && getVertex(graph, sh, ent, 0) == NULL) GraphAddVertex(graph, sh, ent);
-             return (doext(sh, se));
+             return (doext(sh, ent, se));
 
 #ifdef XLUA
     case LUA:


### PR DESCRIPTION
**Problem**

Cells whose expression uses `@ext()` with cell references in the argument (e.g. `@ext(\"cmd\", A1/B1)`) show stale values after loading a file: the external command runs before the referenced cells are computed. A manual recalc afterwards fixes them. Editing the referenced cells also fails to re-evaluate the @ext cell.

**Root cause**

Dependency edges are recorded during evaluation in `eval()`/`seval()` only when `ent` is non-NULL, but `doext()` evaluates the @ext command and value expressions with `ent = NULL`. The @ext cell therefore has no edges in the dependency graph, and `EvalBottomUp()` evaluates it in the first wave, before its inputs.

**Fix**

Pass the calling cell's `ent` from the `EXT` case in `seval()` down into `doext()` and use it when evaluating the arguments, so the edges are recorded and evaluation is correctly ordered.

Verified: correct values right after load, after save/reload round-trips, and when the referenced cells change during a session.