### PR TITLE
Fix segmentation fault when using LUA files

### DIFF
--- a/src/gram.y
+++ b/src/gram.y
@@ -1446,6 +1446,9 @@ term:   var                       {
                                   {
                                   #ifdef XLUA
                                   $$ = new(LUA, $4, $6);
+                                  #else
+                                  sc_error("@lua: SC-IM was not compiled with LUA support");
+                                  $$ = new(ERR_, ENULL, ENULL);
                                   #endif
                                   }
         | '@' K_MYROW             { $$ = new(MYROW, ENULL, ENULL);}

--- a/src/lua.c
+++ b/src/lua.c
@@ -431,7 +431,7 @@ char * doLUA(struct sheet * sh, struct ent * ent, struct enode * se, int dg_stor
         case LUA_TSTRING:
             ;
             const char *s = lua_tostring(L, -1);
-            char *ptr = scxmalloc((size_t) s);
+            char *ptr = scxmalloc((size_t) (strlen(s) + 1));
             strcpy(ptr, s);
             return (ptr);
         default:


### PR DESCRIPTION
This PR fixes a segmentation fault crash. The error comes from an very large allocation size coming from a wrong parameter of the allocation method.
In addition to this fix, the PR introduces an error message when the user tries to run a lua file when the program was not compiled with LUA support. 